### PR TITLE
Reintroduce 2.5 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,14 @@ references:
       command: bundle exec standardrb
 
 jobs:
+  "ruby-2-5":
+    docker:
+      - image: circleci/ruby:2.5
+    steps:
+      - checkout
+      - ruby/install-deps
+      - <<: *unit
+
   "ruby-2-6":
     docker:
       - image: circleci/ruby:2.6
@@ -49,6 +57,7 @@ workflows:
   version: 2
   build:
     jobs:
+      - "ruby-2-5"
       - "ruby-2-6"
       - "ruby-2-7"
       - "ruby-3-0"

--- a/.standard.yml
+++ b/.standard.yml
@@ -1,1 +1,1 @@
-ruby_version: 2.6.6
+ruby_version: 2.5.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## HEAD (unreleased)
 
+- Reintroduce Ruby 2.5 support (https://github.com/zombocom/dead_end/pull/90)
 - Support naked braces/brackets/parens, invert labels on banner (https://github.com/zombocom/dead_end/pull/89)
 - Handle mismatched end when using rescue without begin (https://github.com/zombocom/dead_end/pull/83)
 - CLI returns non-zero exit code when syntax error is found (https://github.com/zombocom/dead_end/pull/86)

--- a/lib/dead_end/around_block_scan.rb
+++ b/lib/dead_end/around_block_scan.rb
@@ -194,7 +194,7 @@ module DeadEnd
     end
 
     private def after_lines
-      @code_lines[after_index.next..] || []
+      @code_lines[after_index.next..-1] || []
     end
   end
 end

--- a/lib/dead_end/clean_document.rb
+++ b/lib/dead_end/clean_document.rb
@@ -231,7 +231,7 @@ module DeadEnd
     #
     def join_consecutive!
       consecutive_groups = @document.select(&:ignore_newline_not_beg?).map do |code_line|
-        take_while_including(code_line.index..) do |line|
+        take_while_including(code_line.index..-1) do |line|
           line.ignore_newline_not_beg?
         end
       end
@@ -252,7 +252,7 @@ module DeadEnd
     #     expect(lines[1].to_s).to eq("")
     def join_trailing_slash!
       trailing_groups = @document.select(&:trailing_slash?).map do |code_line|
-        take_while_including(code_line.index..) { |x| x.trailing_slash? }
+        take_while_including(code_line.index..-1) { |x| x.trailing_slash? }
       end
       join_groups(trailing_groups)
       self
@@ -286,7 +286,7 @@ module DeadEnd
         )
 
         # Hide the rest of the lines
-        lines[1..].each do |line|
+        lines[1..-1].each do |line|
           # The above lines already have newlines in them, if add more
           # then there will be double newline, use an empty line instead
           @document[line.index] = CodeLine.new(line: "", index: line.index, lex: [])
@@ -300,7 +300,7 @@ module DeadEnd
     # Like `take_while` except when it stops
     # iterating, it also returns the line
     # that caused it to stop
-    def take_while_including(range = 0..)
+    def take_while_including(range = 0..-1)
       take_next_and_stop = false
       @document[range].take_while do |line|
         next if take_next_and_stop

--- a/lib/dead_end/lex_all.rb
+++ b/lib/dead_end/lex_all.rb
@@ -15,7 +15,7 @@ module DeadEnd
       last_lineno = source_lines.count
 
       until lineno >= last_lineno
-        lines = source_lines[lineno..]
+        lines = source_lines[lineno..-1]
 
         @lex.concat(Ripper.lex(lines.join, "-", lineno + 1))
         lineno = @lex.last.first.first + 1

--- a/lib/dead_end/who_dis_syntax_error.rb
+++ b/lib/dead_end/who_dis_syntax_error.rb
@@ -63,10 +63,12 @@ module DeadEnd
         if $1
           character = $1.to_sym
           @unmatched_symbol = CHARACTERS[character] || character
+          @unmatched_symbol = :end if @unmatched_symbol == :keyword_end
         end
         @error_symbol = :unmatched_syntax
       when /unexpected '(?<unmatched_symbol>.*)'/
-        @unmatched_symbol = $1.to_sym if $1
+        @unmatched_symbol = $1.to_sym
+        @unmatched_symbol = :end if @unmatched_symbol == :keyword_end
         @error_symbol = :unmatched_syntax
       when /unexpected `end'/, # Ruby 2.7 and 3.0
            /unexpected end/, # Ruby 2.6


### PR DESCRIPTION
While 2.5 is EOL DeadEnd is a dependency of Derailed which is locked at 2.5+ support.

It's not much more work to support that version 🤞🏻.

The only syntax ability we lose is "endless range" which is nice, but not critical.