### PR TITLE
Use color if stdout is a tty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD (unreleased)
 
+- Don't print terminal color codes when output is not tty (https://github.com/zombocom/dead_end/pull/91)
+
 ## 2.0.1
 
 - Reintroduce Ruby 2.5 support (https://github.com/zombocom/dead_end/pull/90)

--- a/exe/dead_end
+++ b/exe/dead_end
@@ -5,7 +5,6 @@ require "optparse"
 require_relative "../lib/dead_end"
 
 options = {}
-options[:terminal] = true
 options[:record_dir] = ENV["DEAD_END_RECORD_DIR"]
 
 parser = OptionParser.new do |opts|
@@ -44,6 +43,10 @@ parser = OptionParser.new do |opts|
 
   opts.on("--record <dir>", "When enabled, records the steps used to search for a syntax error to the given directory") do |v|
     options[:record_dir] = v
+  end
+
+  opts.on("--terminal", "Enable terminal highlighting") do |v|
+    options[:terminal] = true
   end
 
   opts.on("--no-terminal", "Disable terminal highlighting") do |v|

--- a/lib/dead_end/display_invalid_blocks.rb
+++ b/lib/dead_end/display_invalid_blocks.rb
@@ -9,8 +9,8 @@ module DeadEnd
   class DisplayInvalidBlocks
     attr_reader :filename
 
-    def initialize(code_lines:, blocks:, io: $stderr, filename: nil, terminal: false, invalid_obj: WhoDisSyntaxError::Null.new)
-      @terminal = terminal
+    def initialize(code_lines:, blocks:, io: $stderr, filename: nil, terminal: nil, invalid_obj: WhoDisSyntaxError::Null.new)
+      @terminal = terminal.nil? ? io.isatty : terminal
       @filename = filename
       @io = io
 

--- a/lib/dead_end/internals.rb
+++ b/lib/dead_end/internals.rb
@@ -28,14 +28,13 @@ module DeadEnd
       call(
         source: Pathname(filename).read,
         filename: filename,
-        terminal: true
       )
     end
 
     raise e
   end
 
-  def self.call(source:, filename:, terminal: false, record_dir: nil, timeout: TIMEOUT_DEFAULT, io: $stderr)
+  def self.call(source:, filename:, terminal: nil, record_dir: nil, timeout: TIMEOUT_DEFAULT, io: $stderr)
     search = nil
     Timeout.timeout(timeout) do
       record_dir ||= ENV["DEBUG"] ? "tmp" : nil

--- a/spec/integration/exe_cli_spec.rb
+++ b/spec/integration/exe_cli_spec.rb
@@ -23,7 +23,7 @@ module DeadEnd
 
     it "parses invalid code" do
       ruby_file = fixtures_dir.join("this_project_extra_def.rb.txt")
-      out = exe("#{ruby_file} --no-terminal")
+      out = exe(ruby_file)
 
       expect(out.strip).to include("Missing `end` detected")
       expect(out.strip).to include("❯ 36      def filename")
@@ -32,13 +32,13 @@ module DeadEnd
     end
 
     it "handles heredocs" do
+      lines = fixtures_dir.join("rexe.rb.txt").read.lines
       Tempfile.create do |file|
-        lines = fixtures_dir.join("rexe.rb.txt").read.lines
         lines.delete_at(85 - 1)
 
         Pathname(file.path).write(lines.join)
 
-        out = exe("#{file.path} --no-terminal")
+        out = exe(file.path)
 
         expect(out).to include(<<~EOM.indent(4))
              16  class Rexe
@@ -47,6 +47,19 @@ module DeadEnd
           ❯ 148    end
             551  end
         EOM
+      end
+    end
+
+    describe "terminal coloring" do
+      # When ruby sub shells it is not a interactive shell and dead_end will
+      # default to no coloring.
+
+      it "passing --terminal will force color codes" do
+        ruby_file = fixtures_dir.join("this_project_extra_def.rb.txt")
+        out = exe("#{ruby_file} --terminal")
+
+        expect(out.strip).to include("Missing `end` detected")
+        expect(out.strip).to include("\e[0m❯ 36  \e[1;3m    def filename")
       end
     end
 


### PR DESCRIPTION
It's quite commen for commands use check if the output is a terminal or for and use that to determine if it should print colors.

When you print these codes to an none interactive shell it looks like. This could be build tools integrated in ides or Ci.
```
        4  describe Iso20022::Camt053 do
    [0m  223    describe "::Parser", :aggregate_failures do
    [0m❯ 376  [1;3m    fdescribe "DNB cryptic description" do
    [0m❯ 400  [1;3m    end
    [0m❯ 401  [1;3m    end
    [0m  535    end
    [0m  536  end
    [0m
```

This fixes my case. It would proabaly be better if I spent a little more time and check each place its written. Like at https://github.com/zombocom/dead_end/blob/2e3807649d7f999cc3e42ebba0792f8701a79373/lib/dead_end/display_invalid_blocks.rb#L50 we could check .@io 

What's you think? I wanted to open a minimal PR so check if you have any plans for this