### PR TITLE
Backport workaround for running on ruby/ruby repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Debug functionality enabled by `DEBUG=1` env var is now under `SYNTAX_SUGGEST_DEBUG=1`. Note this is not a stable interface or feature. Output content is subject to change without major version change (https://github.com/zombocom/dead_end/pull/149)
 - Enable/Disable dead_end by using the `dead_end` kwarg in `detailed_message` (https://github.com/zombocom/dead_end/pull/147)
 - Respect `highlight` kwarg in Ruby 3.2's `detailed_message` to enable/disable control characters (https://github.com/zombocom/dead_end/pull/147)
+- Added workarounds for running on ruby/ruby repo (https://github.com/ruby/syntax_suggest/pull/156)
 
 ## 4.0.0
 

--- a/spec/integration/exe_cli_spec.rb
+++ b/spec/integration/exe_cli_spec.rb
@@ -5,7 +5,11 @@ require_relative "../spec_helper"
 module SyntaxSuggest
   RSpec.describe "exe" do
     def exe_path
-      root_dir.join("exe").join("syntax_suggest")
+      if ruby_core?
+        root_dir.join("../libexec").join("syntax_suggest")
+      else
+        root_dir.join("exe").join("syntax_suggest")
+      end
     end
 
     def exe(cmd)

--- a/spec/integration/ruby_command_line_spec.rb
+++ b/spec/integration/ruby_command_line_spec.rb
@@ -46,6 +46,8 @@ module SyntaxSuggest
     end
 
     it "detects require error and adds a message with auto mode" do
+      skip if ruby_core?
+
       Dir.mktmpdir do |dir|
         tmpdir = Pathname(dir)
         script = tmpdir.join("script.rb")
@@ -77,6 +79,7 @@ module SyntaxSuggest
     it "annotates a syntax error in Ruby 3.2+ when require is not used" do
       pending("Support for SyntaxError#detailed_message monkeypatch needed https://gist.github.com/schneems/09f45cc23b9a8c46e9af6acbb6e6840d?permalink_comment_id=4172585#gistcomment-4172585")
 
+      skip if ruby_core?
       skip if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("3.2")
 
       Dir.mktmpdir do |dir|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -43,6 +43,10 @@ def fixtures_dir
   spec_dir.join("fixtures")
 end
 
+def ruby_core?
+  !root_dir.join("syntax_suggest.gemspec").exist?
+end
+
 def code_line_array(source)
   SyntaxSuggest::CleanDocument.new(source: source).call.lines
 end

--- a/spec/unit/api_spec.rb
+++ b/spec/unit/api_spec.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 require_relative "../spec_helper"
-require "ruby-prof"
+begin
+  require "ruby-prof"
+rescue LoadError
+end
 
 module SyntaxSuggest
   RSpec.describe "Top level SyntaxSuggest api" do


### PR DESCRIPTION
I added `test-syntax-suggest` for `ruby/ruby` CI at https://github.com/ruby/ruby/pull/6287

We need to some of workarounds about `syntax_suggest`.

