### PR TITLE
Do not output "Syntax OK" when there's an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## HEAD (unreleased)
 
-- [Breaking] Output "Syntax OK" will no longer be output when `syntax_suggest` is fired due to a syntax error.
+- [Breaking] Output "Syntax OK" will no longer be output when `syntax_suggest` is fired due to a syntax error. (https://github.com/ruby/syntax_suggest/pull/158)
 - [Breaking] Rename `dead_end` to `syntax_suggest` (https://github.com/zombocom/dead_end/pull/154)
 - [Breaking] Lazy loading moved from `autoload` to manually checking for constants and requiring `dead_end/api`. To manually use any SyntaxSuggest internals you MUST require `dead_end/api`, otherwise it will be lazy loaded on syntax error (https://github.com/zombocom/dead_end/pull/148)
 - Default to highlighted output on Ruby 3.2 (https://github.com/zombocom/dead_end/pull/150)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## HEAD (unreleased)
 
+- [Breaking] Output "Syntax OK" will no longer be output when `syntax_suggest` is fired due to a syntax error.
 - [Breaking] Rename `dead_end` to `syntax_suggest` (https://github.com/zombocom/dead_end/pull/154)
 - [Breaking] Lazy loading moved from `autoload` to manually checking for constants and requiring `dead_end/api`. To manually use any SyntaxSuggest internals you MUST require `dead_end/api`, otherwise it will be lazy loaded on syntax error (https://github.com/zombocom/dead_end/pull/148)
 - Default to highlighted output on Ruby 3.2 (https://github.com/zombocom/dead_end/pull/150)

--- a/lib/syntax_suggest/cli.rb
+++ b/lib/syntax_suggest/cli.rb
@@ -65,6 +65,7 @@ module SyntaxSuggest
       )
 
       if display.document_ok?
+        @io.puts "Syntax OK"
         @exit_obj.exit(0)
       else
         @exit_obj.exit(1)

--- a/lib/syntax_suggest/display_invalid_blocks.rb
+++ b/lib/syntax_suggest/display_invalid_blocks.rb
@@ -23,7 +23,6 @@ module SyntaxSuggest
 
     def call
       if document_ok?
-        @io.puts "Syntax OK"
         return self
       end
 

--- a/spec/integration/ruby_command_line_spec.rb
+++ b/spec/integration/ruby_command_line_spec.rb
@@ -150,5 +150,21 @@ module SyntaxSuggest
         expect(out).to_not include("Could not find filename")
       end
     end
+
+    it "does not say 'syntax ok' when a syntax error fires" do
+      Dir.mktmpdir do |dir|
+        tmpdir = Pathname(dir)
+        script = tmpdir.join("script.rb")
+        script.write <<~'EOM'
+          break
+        EOM
+
+        out = `ruby -I#{lib_dir} -rsyntax_suggest -e "require_relative '#{script}'" 2>&1`
+
+        expect($?.success?).to be_falsey
+        expect(out.downcase).to_not include("syntax ok")
+        puts out
+      end
+    end
   end
 end

--- a/spec/unit/api_spec.rb
+++ b/spec/unit/api_spec.rb
@@ -25,7 +25,7 @@ module SyntaxSuggest
         io: io
       )
 
-      expect(io.string.strip).to eq("Syntax OK")
+      expect(io.string.strip).to eq("")
     end
 
     it "raises original error with warning if a non-syntax error is passed" do

--- a/spec/unit/display_invalid_blocks_spec.rb
+++ b/spec/unit/display_invalid_blocks_spec.rb
@@ -25,7 +25,7 @@ module SyntaxSuggest
         code_lines: search.code_lines
       )
       display.call
-      expect(io.string).to include("Syntax OK")
+      expect(io.string).to include("")
     end
 
     it "selectively prints to terminal if input is a tty by default" do


### PR DESCRIPTION
Due to a problem with ripper we do not recognize `break` as invalid code. It's confusing that "Syntax OK" is output in that case.

When there's no syntax error, the algorithm should not say anything. The exception is in the CLI and that's for compatibility with `ruby -wc`

```
$ cat /tmp/break.rb
break
⛄️ 3.1.2 🚀 /Users/rschneeman/Documents/projects/syntax_suggest (schneems/no-syntax-not-okay-break)
$ ruby -wc /tmp/break.rb
Syntax OK
```

> Note that this is invalid, running this code will raise a Syntax error.

```
$ exe/syntax_suggest /tmp/break.rb
Syntax OK
```

Close #157