### PR TITLE
Replace unicode arrow with right angle bracket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD (unreleased)
 
+## 1.0.1
+
 - Replace `❯` with `>` in error output for compatability with more fonts (https://github.com/ruby/syntax_suggest/pull/161)
 
 ## 1.0.0 (Library renamed to syntax_suggest )

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD (unreleased)
 
+- Replace `❯` with `>` in error output for compatability with more fonts (https://github.com/ruby/syntax_suggest/pull/161)
+
 ## 1.0.0 (Library renamed to syntax_suggest )
 
 - [Breaking] Output "Syntax OK" will no longer be output when `syntax_suggest` is fired due to a syntax error. (https://github.com/ruby/syntax_suggest/pull/158)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    syntax_suggest (1.0.0)
+    syntax_suggest (1.0.1)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ An error in your code forces you to stop. SyntaxSuggest helps you find those err
 Unmatched `end', missing keyword (`do', `def`, `if`, etc.) ?
 
   1  class Dog
-❯ 2    defbark
-❯ 4    end
+> 2    defbark
+> 4    end
   5  end
 ```
 
@@ -72,9 +72,9 @@ end
 ```
 Unmatched keyword, missing `end' ?
 
-❯ 1  class Dog
-❯ 2    def bark
-❯ 4  end
+> 1  class Dog
+> 2    def bark
+> 4  end
 ```
 
 - Missing keyword
@@ -95,8 +95,8 @@ Unmatched `end', missing keyword (`do', `def`, `if`, etc.) ?
 
   1  class Dog
   2    def speak
-❯ 3      @sounds.each |sound|
-❯ 5      end
+> 3      @sounds.each |sound|
+> 5      end
   6    end
   7  end
 ```
@@ -117,8 +117,8 @@ end
 Unmatched `(', missing `)' ?
 
   1  class Dog
-❯ 2    def speak(sound
-❯ 4    end
+> 2    def speak(sound
+> 4    end
   5  end
 ```
 
@@ -137,7 +137,7 @@ syntax error, unexpected end-of-input
 
   1  class Dog
   2    def meals_last_month
-❯ 3      puts 3 *
+> 3      puts 3 *
   4    end
   5  end
 ```

--- a/lib/syntax_suggest/capture_code_context.rb
+++ b/lib/syntax_suggest/capture_code_context.rb
@@ -140,7 +140,7 @@ module SyntaxSuggest
     # However due to https://github.com/ruby/syntax_suggest/issues/32
     # the problem line will be identified as:
     #
-    #  ❯ class Dog       # 1
+    #  > class Dog       # 1
     #
     # Because lines 2, 3, and 4 are technically valid code and are expanded
     # first, deemed valid, and hidden. We need to un-hide the matching end
@@ -200,7 +200,7 @@ module SyntaxSuggest
     #
     # the problem line will be identified as:
     #
-    #  ❯ end            # 4
+    #  > end            # 4
     #
     # This happens because lines 1, 2, and 3 are technically valid code and are expanded
     # first, deemed valid, and hidden. We need to un-hide the matching keyword on

--- a/lib/syntax_suggest/cli.rb
+++ b/lib/syntax_suggest/cli.rb
@@ -92,8 +92,8 @@ module SyntaxSuggest
 
             # ...
 
-              ❯ 10  defdog
-              ❯ 15  end
+              > 10  defdog
+              > 15  end
 
           ENV options:
 

--- a/lib/syntax_suggest/display_code_with_line_numbers.rb
+++ b/lib/syntax_suggest/display_code_with_line_numbers.rb
@@ -14,8 +14,8 @@ module SyntaxSuggest
   #   # =>
   #       1
   #       2  def cat
-  #     ❯ 3    Dir.chdir
-  #     ❯ 4    end
+  #     > 3    Dir.chdir
+  #     > 4    end
   #       5  end
   #       6
   class DisplayCodeWithLineNumbers
@@ -50,7 +50,7 @@ module SyntaxSuggest
     private def format(contents:, number:, empty:, highlight: false)
       string = +""
       string << if highlight
-        "❯ "
+        "> "
       else
         "  "
       end

--- a/lib/syntax_suggest/version.rb
+++ b/lib/syntax_suggest/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SyntaxSuggest
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end

--- a/spec/integration/ruby_command_line_spec.rb
+++ b/spec/integration/ruby_command_line_spec.rb
@@ -72,7 +72,7 @@ module SyntaxSuggest
         out = `ruby -I#{lib_dir} -rsyntax_suggest #{require_rb} 2>&1`
 
         expect($?.success?).to be_falsey
-        expect(out).to include('❯  5    it "flerg"').once
+        expect(out).to include('>  5    it "flerg"').once
       end
     end
 
@@ -101,7 +101,7 @@ module SyntaxSuggest
         out = `ruby -I#{lib_dir} -rsyntax_suggest #{script} 2>&1`
 
         expect($?.success?).to be_falsey
-        expect(out).to include('❯  5    it "flerg"').once
+        expect(out).to include('>  5    it "flerg"').once
       end
     end
 

--- a/spec/integration/syntax_suggest_spec.rb
+++ b/spec/integration/syntax_suggest_spec.rb
@@ -29,9 +29,9 @@ module SyntaxSuggest
              6  class SyntaxTree < Ripper
            170    def self.parse(source)
            174    end
-        ❯  754    def on_args_add(arguments, argument)
-        ❯  776    class ArgsAddBlock
-        ❯  810    end
+        >  754    def on_args_add(arguments, argument)
+        >  776    class ArgsAddBlock
+        >  810    end
           9233  end
       EOM
     end
@@ -54,10 +54,10 @@ module SyntaxSuggest
 
       expect(io.string).to_not include("def ruby_install_binstub_path")
       expect(io.string).to include(<<~'EOM')
-        ❯ 1067    def add_yarn_binary
-        ❯ 1068      return [] if yarn_preinstalled?
-        ❯ 1069  |
-        ❯ 1075    end
+        > 1067    def add_yarn_binary
+        > 1068      return [] if yarn_preinstalled?
+        > 1069  |
+        > 1075    end
       EOM
     end
 
@@ -73,9 +73,9 @@ module SyntaxSuggest
 
       expect(io.string).to include(<<~'EOM')
            1  Rails.application.routes.draw do
-        ❯ 113    namespace :admin do
-        ❯ 116    match "/foobar(*path)", via: :all, to: redirect { |_params, req|
-        ❯ 120    }
+        > 113    namespace :admin do
+        > 116    match "/foobar(*path)", via: :all, to: redirect { |_params, req|
+        > 120    }
           121  end
       EOM
     end
@@ -94,8 +94,8 @@ module SyntaxSuggest
            1  describe "webmock tests" do
           22    it "body" do
           27      query = Cutlass::FunctionQuery.new(
-        ❯ 28        port: port
-        ❯ 29        body: body
+        > 28        port: port
+        > 29        body: body
           30      ).call
           34    end
           35  end
@@ -118,9 +118,9 @@ module SyntaxSuggest
            7      REQUIRED_BY = {}
            9      attr_reader   :name
           10      attr_writer   :cost
-        ❯ 13      def initialize(name)
-        ❯ 18      def self.reset!
-        ❯ 25      end
+        > 13      def initialize(name)
+        > 18      def self.reset!
+        > 25      end
           73    end
           74  end
       EOM
@@ -140,9 +140,9 @@ module SyntaxSuggest
 
       expect(out).to include(<<~EOM)
            16  class Rexe
-        ❯  77    class Lookups
-        ❯  78      def input_modes
-        ❯ 148    end
+        >  77    class Lookups
+        >  78      def input_modes
+        > 148    end
           551  end
       EOM
     end
@@ -161,9 +161,9 @@ module SyntaxSuggest
       expect(out).to include(<<~EOM)
            16  class Rexe
            18    VERSION = '1.5.1'
-        ❯  77    class Lookups
-        ❯ 140      def format_requires
-        ❯ 148    end
+        >  77    class Lookups
+        > 140      def format_requires
+        > 148    end
           551  end
       EOM
     end
@@ -182,9 +182,9 @@ module SyntaxSuggest
       )
       out = io.string
       expect(out).to include(<<~EOM)
-        ❯ 1  def call          # 0
-        ❯ 3    end # one       # 2
-        ❯ 4  end # two         # 3
+        > 1  def call          # 0
+        > 3    end # one       # 2
+        > 4  end # two         # 3
       EOM
     end
 
@@ -202,9 +202,9 @@ module SyntaxSuggest
       )
       out = io.string
       expect(out).to include(<<~EOM)
-        ❯ 1  class Dog
-        ❯ 2    def bark
-        ❯ 4  end
+        > 1  class Dog
+        > 2    def bark
+        > 4  end
       EOM
     end
   end

--- a/spec/unit/clean_document_spec.rb
+++ b/spec/unit/clean_document_spec.rb
@@ -66,9 +66,9 @@ module SyntaxSuggest
           highlight_lines: lines[0]
         ).call
       ).to eq(<<~'EOM')
-        ❯ 1  User
-        ❯ 2    .where(name: 'schneems')
-        ❯ 3    .first
+        > 1  User
+        > 2    .where(name: 'schneems')
+        > 3    .first
       EOM
     end
 
@@ -169,8 +169,8 @@ module SyntaxSuggest
         ).call
       ).to eq(<<~'EOM')
           1  context "timezones workaround" do
-        ❯ 2    it "should receive a time in UTC format and return the time with the"\
-        ❯ 3      "office's UTC offset substracted from it" do
+        > 2    it "should receive a time in UTC format and return the time with the"\
+        > 3      "office's UTC offset substracted from it" do
           4      travel_to DateTime.new(2020, 10, 1, 10, 0, 0) do
           5        office = build(:office)
           6      end
@@ -227,9 +227,9 @@ module SyntaxSuggest
           highlight_lines: lines[0]
         ).call
       ).to eq(<<~'EOM')
-        ❯ 1  it "should " \
-        ❯ 2     "keep " \
-        ❯ 3     "going " do
+        > 1  it "should " \
+        > 2     "keep " \
+        > 3     "going " do
           4  end
       EOM
     end

--- a/spec/unit/cli_spec.rb
+++ b/spec/unit/cli_spec.rb
@@ -58,7 +58,7 @@ module SyntaxSuggest
 
       expect(exit_obj.called?).to be_truthy
       expect(exit_obj.value).to eq(1)
-      expect(out.strip).to include("❯ 36      def filename")
+      expect(out.strip).to include("> 36      def filename")
     end
 
     it "parses valid code with flags" do

--- a/spec/unit/code_search_spec.rb
+++ b/spec/unit/code_search_spec.rb
@@ -185,8 +185,8 @@ module SyntaxSuggest
         expect(search.record_dir.join("1-add-1-(3__4).txt").read).to include(<<~EOM)
             1  class OH
             2    def hello
-          ❯ 3    def hai
-          ❯ 4    end
+          > 3    def hai
+          > 4    end
             5  end
         EOM
       end
@@ -245,7 +245,7 @@ module SyntaxSuggest
         ).call
 
         expect(document).to include(<<~'EOM')
-          ❯ 36      def filename
+          > 36      def filename
         EOM
       end
 
@@ -295,9 +295,9 @@ module SyntaxSuggest
              1  require 'rails_helper'
              2
              3  RSpec.describe AclassNameHere, type: :worker do
-          ❯  4    describe "thing" do
-          ❯ 16    end # line 16 accidental end, but valid block
-          ❯ 30    end # mismatched due to 16
+          >  4    describe "thing" do
+          > 16    end # line 16 accidental end, but valid block
+          > 30    end # mismatched due to 16
             31  end
         EOM
       end

--- a/spec/unit/display_invalid_blocks_spec.rb
+++ b/spec/unit/display_invalid_blocks_spec.rb
@@ -52,7 +52,7 @@ module SyntaxSuggest
       )
       display.call
       expect(io.string).to include([
-        "❯ 2  ",
+        "> 2  ",
         DisplayCodeWithLineNumbers::TERMINAL_HIGHLIGHT,
         "  def hello"
       ].join)
@@ -69,7 +69,7 @@ module SyntaxSuggest
         code_lines: code_lines
       )
       display.call
-      expect(io.string).to include("❯ 2    def hello")
+      expect(io.string).to include("> 2    def hello")
     end
 
     it "outputs to io when using `call`" do
@@ -92,7 +92,7 @@ module SyntaxSuggest
         code_lines: code_lines
       )
       display.call
-      expect(io.string).to include("❯ 2    def hello")
+      expect(io.string).to include("> 2    def hello")
     end
 
     it " wraps code with github style codeblocks" do
@@ -116,7 +116,7 @@ module SyntaxSuggest
       ).call
       expect(io.string).to include(<<~EOM)
           1  class OH
-        ❯ 2    def hello
+        > 2    def hello
           4    def hai
           5    end
           6  end
@@ -143,7 +143,7 @@ module SyntaxSuggest
 
       expect(io.string).to include([
         "  1  class OH",
-        "❯ 2    def hello",
+        "> 2    def hello",
         "  4    end",
         "  5  end",
         ""
@@ -161,7 +161,7 @@ module SyntaxSuggest
       expect(io.string).to include(
         [
           "  1  class OH",
-          ["❯ 2  ", DisplayCodeWithLineNumbers::TERMINAL_HIGHLIGHT, "  def hello"].join,
+          ["> 2  ", DisplayCodeWithLineNumbers::TERMINAL_HIGHLIGHT, "  def hello"].join,
           "  4    end",
           "  5  end",
           ""


### PR DESCRIPTION
There was a report where the unicode character `"\u276F"` i.e. `❯` would not render on some older fonts. To improve compatibility, we are switching to the standard right angle bracket `>`.