### PR TITLE
Build on #163: No longer need PathnameFromMessage with SyntaxError#path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## HEAD (unreleased)
 
+- Native support of `SyntaxError#path`, support 3.2.0-preview3 will be dropped with the release of 3.2.0-preview4 ()
 - Added dependabot for GitHub Actions (https://github.com/ruby/syntax_suggest/pull/160)
 
 ## 1.0.1

--- a/lib/syntax_suggest/core_ext.rb
+++ b/lib/syntax_suggest/core_ext.rb
@@ -25,15 +25,12 @@ if SyntaxError.method_defined?(:detailed_message)
       require "syntax_suggest/api" unless defined?(SyntaxSuggest::DEFAULT_VALUE)
 
       message = super
-      file = if highlight
-        SyntaxSuggest::PathnameFromMessage.new(super(highlight: false, **kwargs)).call.name
-      else
-        SyntaxSuggest::PathnameFromMessage.new(message).call.name
-      end
-
-      io = SyntaxSuggest::MiniStringIO.new
+      file = path
 
       if file
+        file = Pathname.new(file)
+        io = SyntaxSuggest::MiniStringIO.new
+
         SyntaxSuggest.call(
           io: io,
           source: file.read,

--- a/lib/syntax_suggest/core_ext.rb
+++ b/lib/syntax_suggest/core_ext.rb
@@ -25,7 +25,16 @@ if SyntaxError.method_defined?(:detailed_message)
       require "syntax_suggest/api" unless defined?(SyntaxSuggest::DEFAULT_VALUE)
 
       message = super
-      file = path
+
+      file = if respond_to?(:path)
+        path
+      elsif highlight
+        # This branch will be removed when the next Ruby 3.2 preview is released with
+        # support for SyntaxError#path
+        SyntaxSuggest::PathnameFromMessage.new(super(highlight: false, **kwargs)).call.name
+      else
+        SyntaxSuggest::PathnameFromMessage.new(message).call.name
+      end
 
       if file
         file = Pathname.new(file)


### PR DESCRIPTION
Original:

```
https://bugs.ruby-lang.org/issues/19138

Co-authored-by: Nobuyoshi Nakada [nobu@ruby-lang.org](mailto:nobu@ruby-lang.org)
```

Added: 

- Support for current releases of 3.2.0-preview
- Changelog
