### PR TITLE
Run with the given ruby command

### DIFF
--- a/spec/integration/exe_cli_spec.rb
+++ b/spec/integration/exe_cli_spec.rb
@@ -13,7 +13,8 @@ module SyntaxSuggest
     end
 
     def exe(cmd)
-      out = run!("#{exe_path} #{cmd}", raise_on_nonzero_exit: false)
+      ruby = ENV.fetch("RUBY", "ruby")
+      out = run!("#{ruby} #{exe_path} #{cmd}", raise_on_nonzero_exit: false)
       puts out if ENV["SYNTAX_SUGGEST_DEBUG"]
       out
     end


### PR DESCRIPTION
Running the file with shebang has a few issues.

* shebang is an OS dependent feature. Many modern UNIX-like OSes support it, but not all, e.g., Windows.
* `env` command may not be in `/usr/bin`.
* "ruby" command may not be "ruby", when `--program-suffix` or other configuration option is used.