### PR TITLE
Hide internal document and detail of `Kernel` monkey patching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## HEAD (unreleased)
 
+- No longer shows the detail of monkey patch as the document (https://github.com/ruby/syntax_suggest/pull/174)
 - Drop CI for Ruby 3.2.0-rc1, now that 3.2.0 is available (https://github.com/ruby/syntax_suggest/pull/172)
 
 ## 1.0.2

--- a/lib/syntax_suggest/core_ext.rb
+++ b/lib/syntax_suggest/core_ext.rb
@@ -66,9 +66,13 @@ if SyntaxError.method_defined?(:detailed_message)
 else
   autoload :Pathname, "pathname"
 
+  #--
   # Monkey patch kernel to ensure that all `require` calls call the same
   # method
+  #++
   module Kernel
+    # :stopdoc:
+
     module_function
 
     alias_method :syntax_suggest_original_require, :require


### PR DESCRIPTION
Fix https://bugs.ruby-lang.org/issues/19285

In particular, the part  hidden from RDoc by this PR is not used in the versions syntax_suggest bundled with.