### PR TITLE
Remove unnecessary `--color` option

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,2 @@
 --format documentation
---color
 --require spec_helper


### PR DESCRIPTION
It is enabled automatically if possible.
Forcing this option makes https://github.com/rspec/rspec-core/pull/3017 useless.