### PR TITLE
The annotation must end with a new line

### DIFF
--- a/lib/syntax_suggest/core_ext.rb
+++ b/lib/syntax_suggest/core_ext.rb
@@ -45,6 +45,8 @@ if SyntaxError.method_defined?(:detailed_message)
             )
             annotation = io.string
 
+            annotation += "\n" unless annotation.end_with?("\n")
+
             annotation + message
           else
             message


### PR DESCRIPTION
syntax_suggest did not work great when there is no new line at the end of the input file.

Input:
```
def foo
end
end # No newline at end of file
```

Previous output:
```
$ ruby test.rb
test.rb: --> test.rb
Unmatched `end', missing keyword (`do', `def`, `if`, etc.) ?
> 1  def foo
> 2  end
> 3  end # No newline at end of filetest.rb:3: syntax error, unexpected `end' (SyntaxError)
end # No newline at end of file
^~~
```

Note that "test.rb:3: ..." is appended to the last line of the annotation.

This change makes sure that the annotation ends with a new line.

New output:
```
$ ruby test.rb
test.rb: --> test.rb
Unmatched `end', missing keyword (`do', `def`, `if`, etc.) ?
> 1  def foo
> 2  end
> 3  end # No newline at end of file
test.rb:3: syntax error, unexpected `end' (SyntaxError)
end # No newline at end of file
^~~
```