### PR TITLE
Clean up output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD (unreleased)
 
+- Reduce line output for increased clarity (https://github.com/ruby/syntax_suggest/pull/190)
+
 ## 1.0.4
 
 - Fix rendering a file without a newline ending (https://github.com/ruby/syntax_suggest/pull/182)

--- a/lib/syntax_suggest/around_block_scan.rb
+++ b/lib/syntax_suggest/around_block_scan.rb
@@ -176,7 +176,7 @@ module SyntaxSuggest
           break
         end
 
-        lines << line
+        lines << line if line.is_kw? || line.is_end?
       end
 
       lines.reverse!
@@ -195,7 +195,7 @@ module SyntaxSuggest
           break
         end
 
-        lines << line
+        lines << line if line.is_kw? || line.is_end?
       end
 
       lines
@@ -316,24 +316,6 @@ module SyntaxSuggest
       indent = before_after_indent.min
       scan_while { |line| line.not_empty? && line.indent >= indent }
 
-      self
-    end
-
-    # TODO: Doc or delete
-    #
-    # I don't remember why this is needed, but it's called in code_context.
-    # It's related to the implementation of `capture_neighbor_context` somehow
-    # and that display improvement is only triggered when there's one visible line
-    #
-    # I think the primary purpose is to not include the current line in the
-    # logic evaluation of `capture_neighbor_context`. If that's true, then
-    # we should fix that method to handle this logic instead of only using
-    # it in one place and together.
-    def start_at_next_line
-      before_index
-      after_index
-      @before_index -= 1
-      @after_index += 1
       self
     end
 

--- a/lib/syntax_suggest/capture_code_context.rb
+++ b/lib/syntax_suggest/capture_code_context.rb
@@ -116,7 +116,6 @@ module SyntaxSuggest
       return unless block.visible_lines.count == 1
 
       around_lines = AroundBlockScan.new(code_lines: @code_lines, block: block)
-        .start_at_next_line
         .capture_neighbor_context
 
       around_lines -= block.lines

--- a/spec/integration/syntax_suggest_spec.rb
+++ b/spec/integration/syntax_suggest_spec.rb
@@ -115,9 +115,6 @@ module SyntaxSuggest
       expect(io.string).to include(<<~'EOM')
            5  module DerailedBenchmarks
            6    class RequireTree
-           7      REQUIRED_BY = {}
-           9      attr_reader   :name
-          10      attr_writer   :cost
         > 13      def initialize(name)
         > 18      def self.reset!
         > 25      end
@@ -160,7 +157,6 @@ module SyntaxSuggest
       out = io.string
       expect(out).to include(<<~EOM)
            16  class Rexe
-           18    VERSION = '1.5.1'
         >  77    class Lookups
         > 140      def format_requires
         > 148    end

--- a/spec/unit/capture_code_context_spec.rb
+++ b/spec/unit/capture_code_context_spec.rb
@@ -16,13 +16,14 @@ module SyntaxSuggest
       EOM
 
       code_lines = CleanDocument.new(source: source).call.lines
-      block = CodeBlock.new(lines: code_lines[0])
+      block = CodeBlock.new(lines: code_lines[3])
 
       display = CaptureCodeContext.new(
         blocks: [block],
         code_lines: code_lines
       )
-      lines = display.call
+
+      lines = display.capture_before_after_kws(block).sort
       expect(lines.join).to eq(<<~'EOM')
         def sit
         end

--- a/spec/unit/display_invalid_blocks_spec.rb
+++ b/spec/unit/display_invalid_blocks_spec.rb
@@ -144,6 +144,7 @@ module SyntaxSuggest
       expect(io.string).to include([
         "  1  class OH",
         "> 2    def hello",
+        "  3    def hai",
         "  4    end",
         "  5  end",
         ""
@@ -162,6 +163,7 @@ module SyntaxSuggest
         [
           "  1  class OH",
           ["> 2  ", DisplayCodeWithLineNumbers::TERMINAL_HIGHLIGHT, "  def hello"].join,
+          "  3    def hai",
           "  4    end",
           "  5  end",
           ""


### PR DESCRIPTION
I previously left a comment stating I didn't know why a certain method existed. In investigating the code in `CaptureCodeContext#capture_before_after_kws` I found that it was added as to give a slightly less noisy output.

The docs for AroundBlockScan#capture_neighbor_context only describe keywords as being a primary concern. I modified that code to only include lines that are keywords or ends. This reduces the output noise even more.

This allows me to remove that `start_at_next_line` method.

One weird side effect of the prior logic is it would cause this code to produce this output:


```
        class OH
          def hello

          def hai
          end
        end
```

```
          1  class OH
        > 2    def hello
          4    def hai
          5    end
          6  end
```


But this code to produce this output:


```
        class OH
          def hello
          def hai
          end
        end
```

```
          1  class OH
        > 2    def hello
          4    end
          5  end
```
Note the missing `def hai`. The only difference between them is that space.

With this change, they're now both consistent.