### PR TITLE
Fix warning message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## HEAD (unreleased)
 
+- Use `SYNTAX_SUGGEST_DEBUG` instead of `DEBUG` env var value in timeout warning message (https://github.com/ruby/syntax_suggest/pull/194)
 - Reduce line output for increased clarity (https://github.com/ruby/syntax_suggest/pull/190)
 
 ## 1.0.4

--- a/lib/syntax_suggest/api.rb
+++ b/lib/syntax_suggest/api.rb
@@ -78,7 +78,7 @@ module SyntaxSuggest
       code_lines: search.code_lines
     ).call
   rescue Timeout::Error => e
-    io.puts "Search timed out SYNTAX_SUGGEST_TIMEOUT=#{timeout}, run with DEBUG=1 for more info"
+    io.puts "Search timed out SYNTAX_SUGGEST_TIMEOUT=#{timeout}, run with SYNTAX_SUGGEST_DEBUG=1 for more info"
     io.puts e.backtrace.first(3).join($/)
   end
 


### PR DESCRIPTION
The env var DEBUG does not work to produce detailed output. It is SYNTAX_SUGGEST_DEBUG. It was changed as part of the dead_end to syntax_suggest migration for Ruby 3.2