### PR TITLE
Use hard-coded filename for executables.

### DIFF
--- a/syntax_suggest.gemspec
+++ b/syntax_suggest.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |spec|
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features|assets)/}) }
   end
   spec.bindir = "exe"
-  spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.executables = ["syntax_suggest"]
   spec.require_paths = ["lib"]
 end


### PR DESCRIPTION
`spec.files.grep(%r{^exe/}) { |f| File.basename(f) }` is not working with `ruby/ruby` repo. Therefore, https://github.com/ruby/ruby/blob/master/libexec/syntax_suggest is not installed with Ruby installation.

I replaced `spec.executables` to simple filename because it's rarely to add new executables. 