### PR TITLE
Handle new eval source location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD (unreleased)
 
+- Handle Ruby 3.3 new eval source location format (https://github.com/ruby/syntax_suggest/pull/200).
+
 ## 1.1.0
 
 - Handle if/else with comment or empty line in branch (https://github.com/ruby/syntax_suggest/pull/193)

--- a/lib/syntax_suggest/pathname_from_message.rb
+++ b/lib/syntax_suggest/pathname_from_message.rb
@@ -13,7 +13,7 @@ module SyntaxSuggest
   #    # => "/tmp/scratch.rb"
   #
   class PathnameFromMessage
-    EVAL_RE = /^\(eval\):\d+/
+    EVAL_RE = /^\(eval.*\):\d+/
     STREAMING_RE = /^-:\d+/
     attr_reader :name
 

--- a/spec/integration/ruby_command_line_spec.rb
+++ b/spec/integration/ruby_command_line_spec.rb
@@ -167,7 +167,7 @@ module SyntaxSuggest
         out = `#{ruby} -I#{lib_dir} -rsyntax_suggest #{script} 2>&1`
 
         expect($?.success?).to be_falsey
-        expect(out).to include("(eval):1")
+        expect(out).to match(/\(eval.*\):1/)
 
         expect(out).to_not include("SyntaxSuggest")
         expect(out).to_not include("Could not find filename")

--- a/spec/unit/pathname_from_message_spec.rb
+++ b/spec/unit/pathname_from_message_spec.rb
@@ -43,6 +43,15 @@ module SyntaxSuggest
       expect(file).to be_falsey
     end
 
+    it "does not output error message on syntax error inside of an (eval at __FILE__:__LINE__)" do
+      message = "(eval at #{__FILE__}:#{__LINE__}):1: invalid multibyte char (UTF-8) (SyntaxError)\n"
+      io = StringIO.new
+      file = PathnameFromMessage.new(message, io: io).call.name
+
+      expect(io.string).to eq("")
+      expect(file).to be_falsey
+    end
+
     it "does not output error message on syntax error inside of streamed code" do
       # An example of streamed code is: $ echo "def foo" | ruby
       message = "-:1: syntax error, unexpected end-of-input\n"


### PR DESCRIPTION
See https://bugs.ruby-lang.org/issues/19755
Ref: https://github.com/ruby/ruby/pull/8070

In Ruby 3.3, using `eval` without providing a source location will now default to `"(eval at #{__FILE__}:#{__LINE__})"`.

cc @schneems @nobu @hsbt 