### PR TITLE
Introduce support for the prism parser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,6 @@ jobs:
   test-disable-prism:
     needs: ruby-versions
     runs-on: ubuntu-latest
-    env:
-      SYNAX_SUGGEST_DISABLE_PRISM: 1
     strategy:
       fail-fast: false
       matrix:
@@ -62,5 +60,5 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
       - name: test
-        run: bin/rake test
+        run: SYNTAX_SUGGEST_DISABLE_PRISM=1 bin/rake test
         continue-on-error: ${{ matrix.ruby == 'head' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,24 @@ jobs:
       - name: test
         run: bin/rake test
         continue-on-error: ${{ matrix.ruby == 'head' }}
+
+  test-disable-prism:
+    needs: ruby-versions
+    runs-on: ubuntu-latest
+    env:
+      SYNAX_SUGGEST_DISABLE_PRISM: 1
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4.1.1
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - name: test
+        run: bin/rake test
+        continue-on-error: ${{ matrix.ruby == 'head' }}

--- a/.standard.yml
+++ b/.standard.yml
@@ -1,1 +1,1 @@
-ruby_version: 2.5.9
+ruby_version: 3.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## HEAD (unreleased)
 
+- Support prism parser (https://github.com/ruby/syntax_suggest/pull/208).
 - No longer supports EOL versions of Ruby.
 - Handle Ruby 3.3 new eval source location format (https://github.com/ruby/syntax_suggest/pull/200).
 

--- a/Gemfile
+++ b/Gemfile
@@ -12,3 +12,4 @@ gem "standard"
 gem "ruby-prof"
 
 gem "benchmark-ips"
+gem "prism"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,6 +12,7 @@ GEM
     parallel (1.21.0)
     parser (3.0.2.0)
       ast (~> 2.4.1)
+    prism (0.18.0)
     rainbow (3.0.0)
     rake (12.3.3)
     regexp_parser (2.1.1)
@@ -56,6 +57,7 @@ PLATFORMS
 
 DEPENDENCIES
   benchmark-ips
+  prism
   rake (~> 12.0)
   rspec (~> 3.0)
   ruby-prof

--- a/lib/syntax_suggest/api.rb
+++ b/lib/syntax_suggest/api.rb
@@ -6,6 +6,7 @@ require "tmpdir"
 require "stringio"
 require "pathname"
 
+# rubocop:disable Style/IdenticalConditionalBranches
 if ENV["SYNTAX_SUGGEST_DISABLE_PRISM"] # For testing dual ripper/prism support
   require "ripper"
 else
@@ -14,10 +15,11 @@ else
   require "ripper"
   begin
     require "prism"
-  rescue LoadError => e
+  rescue LoadError
     require "ripper"
   end
 end
+# rubocop:enable Style/IdenticalConditionalBranches
 
 require "timeout"
 

--- a/lib/syntax_suggest/api.rb
+++ b/lib/syntax_suggest/api.rb
@@ -5,7 +5,20 @@ require_relative "version"
 require "tmpdir"
 require "stringio"
 require "pathname"
-require "ripper"
+
+if ENV["SYNTAX_SUGGEST_DISABLE_PRISM"] # For testing dual ripper/prism support
+  require "ripper"
+else
+  # TODO remove require
+  # Allow both to be loaded to enable more atomic commits
+  require "ripper"
+  begin
+    require "prism"
+  rescue LoadError => e
+    require "ripper"
+  end
+end
+
 require "timeout"
 
 module SyntaxSuggest
@@ -15,6 +28,14 @@ module SyntaxSuggest
 
   class Error < StandardError; end
   TIMEOUT_DEFAULT = ENV.fetch("SYNTAX_SUGGEST_TIMEOUT", 1).to_i
+
+  # SyntaxSuggest.use_prism_parser? [Private]
+  #
+  # Tells us if the prism parser is available for use
+  # or if we should fallback to `Ripper`
+  def self.use_prism_parser?
+    defined?(Prism)
+  end
 
   # SyntaxSuggest.handle_error [Public]
   #
@@ -129,11 +150,20 @@ module SyntaxSuggest
   # SyntaxSuggest.invalid? [Private]
   #
   # Opposite of `SyntaxSuggest.valid?`
-  def self.invalid?(source)
-    source = source.join if source.is_a?(Array)
-    source = source.to_s
+  if defined?(Prism)
+    def self.invalid?(source)
+      source = source.join if source.is_a?(Array)
+      source = source.to_s
 
-    Ripper.new(source).tap(&:parse).error?
+      Prism.parse(source).failure?
+    end
+  else
+    def self.invalid?(source)
+      source = source.join if source.is_a?(Array)
+      source = source.to_s
+
+      Ripper.new(source).tap(&:parse).error?
+    end
   end
 
   # SyntaxSuggest.valid? [Private]
@@ -191,7 +221,9 @@ require_relative "lex_all"
 require_relative "code_line"
 require_relative "code_block"
 require_relative "block_expand"
-require_relative "ripper_errors"
+if !SyntaxSuggest.use_prism_parser?
+  require_relative "ripper_errors"
+end
 require_relative "priority_queue"
 require_relative "unvisited_lines"
 require_relative "around_block_scan"

--- a/lib/syntax_suggest/api.rb
+++ b/lib/syntax_suggest/api.rb
@@ -18,7 +18,7 @@ require "ripper"
 #
 # We also need the ability to control loading of this library
 # so we can test that both modes work correctly in CI.
-if ENV.key?("SYNTAX_SUGGEST_DISABLE_PRISM"]) == false
+if ENV.key?("SYNTAX_SUGGEST_DISABLE_PRISM") == false
   begin
     require "prism"
   rescue LoadError

--- a/lib/syntax_suggest/api.rb
+++ b/lib/syntax_suggest/api.rb
@@ -18,7 +18,9 @@ require "ripper"
 #
 # We also need the ability to control loading of this library
 # so we can test that both modes work correctly in CI.
-if ENV.key?("SYNTAX_SUGGEST_DISABLE_PRISM") == false
+if (value = ENV["SYNTAX_SUGGEST_DISABLE_PRISM"])
+  warn "Skipping loading prism due to SYNTAX_SUGGEST_DISABLE_PRISM=#{value}"
+else
   begin
     require "prism"
   rescue LoadError

--- a/lib/syntax_suggest/api.rb
+++ b/lib/syntax_suggest/api.rb
@@ -5,23 +5,25 @@ require_relative "version"
 require "tmpdir"
 require "stringio"
 require "pathname"
+require "timeout"
 
-# rubocop:disable Style/IdenticalConditionalBranches
-if ENV["SYNTAX_SUGGEST_DISABLE_PRISM"] # For testing dual ripper/prism support
-  require "ripper"
-else
-  # TODO remove require
-  # Allow both to be loaded to enable more atomic commits
-  require "ripper"
+# We need Ripper loaded for `Prism.lex_compat` even if we're using Prism
+# for lexing and parsing
+require "ripper"
+
+# Prism is the new parser, replacing Ripper
+#
+# We need to "dual boot" both for now because syntax_suggest
+# supports older rubies that do not ship with syntax suggest.
+#
+# We also need the ability to control loading of this library
+# so we can test that both modes work correctly in CI.
+if ENV.key?("SYNTAX_SUGGEST_DISABLE_PRISM"]) == false
   begin
     require "prism"
   rescue LoadError
-    require "ripper"
   end
 end
-# rubocop:enable Style/IdenticalConditionalBranches
-
-require "timeout"
 
 module SyntaxSuggest
   # Used to indicate a default value that cannot

--- a/lib/syntax_suggest/clean_document.rb
+++ b/lib/syntax_suggest/clean_document.rb
@@ -279,7 +279,7 @@ module SyntaxSuggest
         )
 
         # Hide the rest of the lines
-        lines[1..-1].each do |line|
+        lines[1..].each do |line|
           # The above lines already have newlines in them, if add more
           # then there will be double newline, use an empty line instead
           @document[line.index] = CodeLine.new(line: "", index: line.index, lex: [])

--- a/lib/syntax_suggest/code_frontier.rb
+++ b/lib/syntax_suggest/code_frontier.rb
@@ -117,7 +117,7 @@ module SyntaxSuggest
 
       if ENV["SYNTAX_SUGGEST_DEBUG"]
         puts "```"
-        puts @queue.peek.to_s
+        puts @queue.peek
         puts "```"
         puts "  @frontier indent:  #{frontier_indent}"
         puts "  @unvisited indent: #{unvisited_indent}"

--- a/lib/syntax_suggest/code_line.rb
+++ b/lib/syntax_suggest/code_line.rb
@@ -180,12 +180,19 @@ module SyntaxSuggest
     #     EOM
     #     expect(lines.first.trailing_slash?).to eq(true)
     #
-    def trailing_slash?
-      last = @lex.last
-      return false unless last
-      return false unless last.type == :on_sp
+    if SyntaxSuggest.use_prism_parser?
+      def trailing_slash?
+        last = @lex.last
+        last&.type == :on_tstring_end
+      end
+    else
+      def trailing_slash?
+        last = @lex.last
+        return false unless last
+        return false unless last.type == :on_sp
 
-      last.token == TRAILING_SLASH
+        last.token == TRAILING_SLASH
+      end
     end
 
     # Endless method detection

--- a/lib/syntax_suggest/code_search.rb
+++ b/lib/syntax_suggest/code_search.rb
@@ -43,7 +43,7 @@ module SyntaxSuggest
 
     def initialize(source, record_dir: DEFAULT_VALUE)
       record_dir = if record_dir == DEFAULT_VALUE
-        ENV["SYNTAX_SUGGEST_RECORD_DIR"] || ENV["SYNTAX_SUGGEST_DEBUG"] ? "tmp" : nil
+        (ENV["SYNTAX_SUGGEST_RECORD_DIR"] || ENV["SYNTAX_SUGGEST_DEBUG"]) ? "tmp" : nil
       else
         record_dir
       end
@@ -73,7 +73,7 @@ module SyntaxSuggest
       if ENV["SYNTAX_SUGGEST_DEBUG"]
         puts "\n\n==== #{filename} ===="
         puts "\n```#{block.starts_at}..#{block.ends_at}"
-        puts block.to_s
+        puts block
         puts "```"
         puts "  block indent:      #{block.current_indent}"
       end

--- a/lib/syntax_suggest/code_search.rb
+++ b/lib/syntax_suggest/code_search.rb
@@ -43,7 +43,7 @@ module SyntaxSuggest
 
     def initialize(source, record_dir: DEFAULT_VALUE)
       record_dir = if record_dir == DEFAULT_VALUE
-        (ENV["SYNTAX_SUGGEST_RECORD_DIR"] || ENV["SYNTAX_SUGGEST_DEBUG"]) ? "tmp" : nil
+        ENV["SYNTAX_SUGGEST_RECORD_DIR"] || ENV["SYNTAX_SUGGEST_DEBUG"] ? "tmp" : nil
       else
         record_dir
       end

--- a/lib/syntax_suggest/display_invalid_blocks.rb
+++ b/lib/syntax_suggest/display_invalid_blocks.rb
@@ -14,7 +14,7 @@ module SyntaxSuggest
       @filename = filename
       @code_lines = code_lines
 
-      @terminal = terminal == DEFAULT_VALUE ? io.isatty : terminal
+      @terminal = (terminal == DEFAULT_VALUE) ? io.isatty : terminal
     end
 
     def document_ok?

--- a/lib/syntax_suggest/display_invalid_blocks.rb
+++ b/lib/syntax_suggest/display_invalid_blocks.rb
@@ -14,7 +14,7 @@ module SyntaxSuggest
       @filename = filename
       @code_lines = code_lines
 
-      @terminal = (terminal == DEFAULT_VALUE) ? io.isatty : terminal
+      @terminal = terminal == DEFAULT_VALUE ? io.isatty : terminal
     end
 
     def document_ok?

--- a/lib/syntax_suggest/explain_syntax.rb
+++ b/lib/syntax_suggest/explain_syntax.rb
@@ -3,6 +3,16 @@
 require_relative "left_right_lex_count"
 
 module SyntaxSuggest
+  class GetParseErrors
+    def self.errors(source)
+      if SyntaxSuggest.use_prism_parser?
+        Prism.parse(source).errors.map(&:message)
+      else
+        RipperErrors.new(source).call.errors
+      end
+    end
+  end
+
   # Explains syntax errors based on their source
   #
   # example:
@@ -94,7 +104,7 @@ module SyntaxSuggest
     # on the original ripper error messages
     def errors
       if missing.empty?
-        return RipperErrors.new(@code_lines.map(&:original).join).call.errors
+        return GetParseErrors.errors(@code_lines.map(&:original).join)
       end
 
       missing.map { |miss| why(miss) }

--- a/lib/syntax_suggest/lex_all.rb
+++ b/lib/syntax_suggest/lex_all.rb
@@ -32,18 +32,15 @@ module SyntaxSuggest
       }
     end
 
-    # rubocop:disable Style/IdenticalConditionalBranches
     if SyntaxSuggest.use_prism_parser?
       def self.lex(source, line_number)
-        # Prism.lex_compat(source, line: line_number).value.sort_by {|values| values[0] }
-        Ripper::Lexer.new(source, "-", line_number).parse.sort_by(&:pos)
+        Prism.lex_compat(source, line: line_number).value.sort_by { |values| values[0] }
       end
     else
       def self.lex(source, line_number)
         Ripper::Lexer.new(source, "-", line_number).parse.sort_by(&:pos)
       end
     end
-    # rubocop:enable Style/IdenticalConditionalBranches
 
     def to_a
       @lex

--- a/lib/syntax_suggest/lex_all.rb
+++ b/lib/syntax_suggest/lex_all.rb
@@ -11,8 +11,8 @@ module SyntaxSuggest
     include Enumerable
 
     def initialize(source:, source_lines: nil)
-      @lex = Ripper::Lexer.new(source, "-", 1).parse.sort_by(&:pos)
-      lineno = @lex.last.pos.first + 1
+      @lex = self.class.lex(source, 1)
+      lineno = @lex.last[0][0] + 1
       source_lines ||= source.lines
       last_lineno = source_lines.length
 
@@ -20,15 +20,27 @@ module SyntaxSuggest
         lines = source_lines[lineno..-1]
 
         @lex.concat(
-          Ripper::Lexer.new(lines.join, "-", lineno + 1).parse.sort_by(&:pos)
+          self.class.lex(lines.join, lineno + 1)
         )
-        lineno = @lex.last.pos.first + 1
+
+        lineno = @lex.last[0].first + 1
       end
 
       last_lex = nil
       @lex.map! { |elem|
-        last_lex = LexValue.new(elem.pos.first, elem.event, elem.tok, elem.state, last_lex)
+        last_lex = LexValue.new(elem[0].first, elem[1], elem[2], elem[3], last_lex)
       }
+    end
+
+    if SyntaxSuggest.use_prism_parser?
+      def self.lex(source, line_number)
+        # Prism.lex_compat(source, line: line_number).value.sort_by {|values| values[0] }
+        Ripper::Lexer.new(source, "-", line_number).parse.sort_by(&:pos)
+      end
+    else
+      def self.lex(source, line_number)
+        Ripper::Lexer.new(source, "-", line_number).parse.sort_by(&:pos)
+      end
     end
 
     def to_a

--- a/lib/syntax_suggest/lex_all.rb
+++ b/lib/syntax_suggest/lex_all.rb
@@ -17,7 +17,7 @@ module SyntaxSuggest
       last_lineno = source_lines.length
 
       until lineno >= last_lineno
-        lines = source_lines[lineno..-1]
+        lines = source_lines[lineno..]
 
         @lex.concat(
           self.class.lex(lines.join, lineno + 1)
@@ -32,6 +32,7 @@ module SyntaxSuggest
       }
     end
 
+    # rubocop:disable Style/IdenticalConditionalBranches
     if SyntaxSuggest.use_prism_parser?
       def self.lex(source, line_number)
         # Prism.lex_compat(source, line: line_number).value.sort_by {|values| values[0] }
@@ -42,6 +43,7 @@ module SyntaxSuggest
         Ripper::Lexer.new(source, "-", line_number).parse.sort_by(&:pos)
       end
     end
+    # rubocop:enable Style/IdenticalConditionalBranches
 
     def to_a
       @lex

--- a/lib/syntax_suggest/ripper_errors.rb
+++ b/lib/syntax_suggest/ripper_errors.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 module SyntaxSuggest
-
   # Capture parse errors from ripper
   #
   # Example:

--- a/lib/syntax_suggest/ripper_errors.rb
+++ b/lib/syntax_suggest/ripper_errors.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module SyntaxSuggest
+
   # Capture parse errors from ripper
   #
   # Example:

--- a/lib/syntax_suggest/scan_history.rb
+++ b/lib/syntax_suggest/scan_history.rb
@@ -118,7 +118,7 @@ module SyntaxSuggest
     # Returns an array of all the CodeLines that exist after
     # the currently scanned block
     private def after_lines
-      @code_lines[@after_index.next..-1] || []
+      @code_lines[@after_index.next..] || []
     end
 
     private def current

--- a/spec/integration/ruby_command_line_spec.rb
+++ b/spec/integration/ruby_command_line_spec.rb
@@ -9,7 +9,7 @@ module SyntaxSuggest
       Dir.mktmpdir do |dir|
         tmpdir = Pathname(dir)
         script = tmpdir.join("script.rb")
-        script.write <<~'EOM'
+        script.write <<~EOM
           puts Kernel.private_methods
         EOM
 
@@ -159,7 +159,7 @@ module SyntaxSuggest
       Dir.mktmpdir do |dir|
         tmpdir = Pathname(dir)
         script = tmpdir.join("script.rb")
-        script.write <<~'EOM'
+        script.write <<~EOM
           $stderr = STDOUT
           eval("def lol")
         EOM
@@ -178,7 +178,7 @@ module SyntaxSuggest
       Dir.mktmpdir do |dir|
         tmpdir = Pathname(dir)
         script = tmpdir.join("script.rb")
-        script.write <<~'EOM'
+        script.write <<~EOM
           break
         EOM
 

--- a/spec/integration/syntax_suggest_spec.rb
+++ b/spec/integration/syntax_suggest_spec.rb
@@ -26,7 +26,7 @@ module SyntaxSuggest
       debug_display(io.string)
       debug_display(benchmark)
 
-      expect(io.string).to include(<<~'EOM')
+      expect(io.string).to include(<<~EOM)
              6  class SyntaxTree < Ripper
            170    def self.parse(source)
            174    end
@@ -54,7 +54,7 @@ module SyntaxSuggest
       end
 
       expect(io.string).to_not include("def ruby_install_binstub_path")
-      expect(io.string).to include(<<~'EOM')
+      expect(io.string).to include(<<~EOM)
         > 1067    def add_yarn_binary
         > 1068      return [] if yarn_preinstalled?
         > 1069  |
@@ -72,7 +72,7 @@ module SyntaxSuggest
       )
       debug_display(io.string)
 
-      expect(io.string).to include(<<~'EOM')
+      expect(io.string).to include(<<~EOM)
            1  Rails.application.routes.draw do
         > 113    namespace :admin do
         > 116    match "/foobar(*path)", via: :all, to: redirect { |_params, req|
@@ -91,7 +91,7 @@ module SyntaxSuggest
       )
       debug_display(io.string)
 
-      expect(io.string).to include(<<~'EOM')
+      expect(io.string).to include(<<~EOM)
            1  describe "webmock tests" do
           22    it "body" do
           27      query = Cutlass::FunctionQuery.new(
@@ -113,7 +113,7 @@ module SyntaxSuggest
       )
       debug_display(io.string)
 
-      expect(io.string).to include(<<~'EOM')
+      expect(io.string).to include(<<~EOM)
            5  module DerailedBenchmarks
            6    class RequireTree
         > 13      def initialize(name)
@@ -166,7 +166,7 @@ module SyntaxSuggest
     end
 
     it "ambiguous end" do
-      source = <<~'EOM'
+      source = <<~EOM
         def call          # 0
             print "lol"   # 1
           end # one       # 2
@@ -186,7 +186,7 @@ module SyntaxSuggest
     end
 
     it "simple regression" do
-      source = <<~'EOM'
+      source = <<~EOM
         class Dog
           def bark
             puts "woof"
@@ -206,7 +206,7 @@ module SyntaxSuggest
     end
 
     it "empty else" do
-      source = <<~'EOM'
+      source = <<~EOM
         class Foo
           def foo
             if cond?

--- a/spec/unit/api_spec.rb
+++ b/spec/unit/api_spec.rb
@@ -8,6 +8,12 @@ end
 
 module SyntaxSuggest
   RSpec.describe "Top level SyntaxSuggest api" do
+    it "doesn't load prism if env var is set" do
+      skip("SYNTAX_SUGGEST_DISABLE_PRISM not set") unless ENV["SYNTAX_SUGGEST_DISABLE_PRISM"]
+
+      expect(SyntaxSuggest.use_prism_parser?).to be_falsey
+    end
+
     it "has a `handle_error` interface" do
       fake_error = Object.new
       def fake_error.message

--- a/spec/unit/around_block_scan_spec.rb
+++ b/spec/unit/around_block_scan_spec.rb
@@ -5,7 +5,7 @@ require_relative "../spec_helper"
 module SyntaxSuggest
   RSpec.describe AroundBlockScan do
     it "continues scan from last location even if scan is false" do
-      source = <<~'EOM'
+      source = <<~EOM
         print 'omg'
         print 'lol'
         print 'haha'

--- a/spec/unit/capture/before_after_keyword_ends_spec.rb
+++ b/spec/unit/capture/before_after_keyword_ends_spec.rb
@@ -5,7 +5,7 @@ require_relative "../../spec_helper"
 module SyntaxSuggest
   RSpec.describe Capture::BeforeAfterKeywordEnds do
     it "before after keyword ends" do
-      source = <<~'EOM'
+      source = <<~EOM
         def nope
           print 'not me'
         end
@@ -36,7 +36,7 @@ module SyntaxSuggest
       ).call
       lines.sort!
 
-      expect(lines.join).to include(<<~'EOM')
+      expect(lines.join).to include(<<~EOM)
         def lol
         end
         def yolo

--- a/spec/unit/capture/falling_indent_lines_spec.rb
+++ b/spec/unit/capture/falling_indent_lines_spec.rb
@@ -5,7 +5,7 @@ require_relative "../../spec_helper"
 module SyntaxSuggest
   RSpec.describe Capture::FallingIndentLines do
     it "on_falling_indent" do
-      source = <<~'EOM'
+      source = <<~EOM
         class OH
           def lol
             print 'lol
@@ -33,7 +33,7 @@ module SyntaxSuggest
       end
       lines.sort!
 
-      expect(lines.join).to eq(<<~'EOM')
+      expect(lines.join).to eq(<<~EOM)
         class OH
           def hello
           end

--- a/spec/unit/capture_code_context_spec.rb
+++ b/spec/unit/capture_code_context_spec.rb
@@ -5,7 +5,7 @@ require_relative "../spec_helper"
 module SyntaxSuggest
   RSpec.describe CaptureCodeContext do
     it "capture_before_after_kws two" do
-      source = <<~'EOM'
+      source = <<~EOM
         class OH
 
           def hello
@@ -23,7 +23,7 @@ module SyntaxSuggest
         code_lines: code_lines
       )
       display.capture_before_after_kws(block)
-      expect(display.sorted_lines.join).to eq(<<~'EOM'.indent(2))
+      expect(display.sorted_lines.join).to eq(<<~EOM.indent(2))
         def hello
         def hai
         end
@@ -31,7 +31,7 @@ module SyntaxSuggest
     end
 
     it "capture_before_after_kws" do
-      source = <<~'EOM'
+      source = <<~EOM
         def sit
         end
 
@@ -50,7 +50,7 @@ module SyntaxSuggest
       )
 
       lines = display.capture_before_after_kws(block).sort
-      expect(lines.join).to eq(<<~'EOM')
+      expect(lines.join).to eq(<<~EOM)
         def sit
         end
         def bark
@@ -60,7 +60,7 @@ module SyntaxSuggest
     end
 
     it "handles ambiguous end" do
-      source = <<~'EOM'
+      source = <<~EOM
         def call          # 0
             print "lol"   # 1
           end # one       # 2
@@ -79,7 +79,7 @@ module SyntaxSuggest
 
       lines = lines.sort.map(&:original)
 
-      expect(lines.join).to eq(<<~'EOM')
+      expect(lines.join).to eq(<<~EOM)
         def call          # 0
           end # one       # 2
         end # two         # 3
@@ -106,7 +106,7 @@ module SyntaxSuggest
       lines = display.call
 
       lines = lines.sort.map(&:original)
-      expect(lines.join).to include(<<~'EOM'.indent(2))
+      expect(lines.join).to include(<<~EOM.indent(2))
         class Lookups
           def format_requires
         end
@@ -114,7 +114,7 @@ module SyntaxSuggest
     end
 
     it "shows ends of captured block" do
-      source = <<~'EOM'
+      source = <<~EOM
         class Dog
           def bark
             puts "woof"
@@ -132,7 +132,7 @@ module SyntaxSuggest
         code_lines: code_lines
       )
       lines = display.call.sort.map(&:original)
-      expect(lines.join).to eq(<<~'EOM')
+      expect(lines.join).to eq(<<~EOM)
         class Dog
           def bark
         end
@@ -140,7 +140,7 @@ module SyntaxSuggest
     end
 
     it "captures surrounding context on falling indent" do
-      source = <<~'EOM'
+      source = <<~EOM
         class Blerg
         end
 
@@ -164,7 +164,7 @@ module SyntaxSuggest
         code_lines: code_lines
       )
       lines = display.call.sort.map(&:original)
-      expect(lines.join).to eq(<<~'EOM')
+      expect(lines.join).to eq(<<~EOM)
         class OH
           def hello
             it "foo" do
@@ -174,7 +174,7 @@ module SyntaxSuggest
     end
 
     it "captures surrounding context on same indent" do
-      source = <<~'EOM'
+      source = <<~EOM
         class Blerg
         end
         class OH
@@ -200,7 +200,7 @@ module SyntaxSuggest
 
       code_lines = CleanDocument.new(source: source).call.lines
       block = CodeBlock.new(lines: code_lines[7..10])
-      expect(block.to_s).to eq(<<~'EOM'.indent(2))
+      expect(block.to_s).to eq(<<~EOM.indent(2))
         def lol
         end
 
@@ -217,7 +217,7 @@ module SyntaxSuggest
         lines: lines
       ).call
 
-      expect(out).to eq(<<~'EOM'.indent(2))
+      expect(out).to eq(<<~EOM.indent(2))
          3  class OH
          8    def lol
          9    end

--- a/spec/unit/capture_code_context_spec.rb
+++ b/spec/unit/capture_code_context_spec.rb
@@ -94,7 +94,7 @@ module SyntaxSuggest
       code_lines = CleanDocument.new(source: source).call.lines
 
       code_lines[0..75].each(&:mark_invisible)
-      code_lines[77..-1].each(&:mark_invisible)
+      code_lines[77..].each(&:mark_invisible)
       expect(code_lines.join.strip).to eq("class Lookups")
 
       block = CodeBlock.new(lines: code_lines[76..149])
@@ -123,7 +123,7 @@ module SyntaxSuggest
 
       code_lines = CleanDocument.new(source: source).call.lines
       block = CodeBlock.new(lines: code_lines)
-      code_lines[1..-1].each(&:mark_invisible)
+      code_lines[1..].each(&:mark_invisible)
 
       expect(block.to_s.strip).to eq("class Dog")
 

--- a/spec/unit/clean_document_spec.rb
+++ b/spec/unit/clean_document_spec.rb
@@ -8,7 +8,7 @@ module SyntaxSuggest
       source = fixtures_dir.join("this_project_extra_def.rb.txt").read
       code_lines = CleanDocument.new(source: source).call.lines
 
-      expect(code_lines[18 - 1].to_s).to eq(<<-'EOL')
+      expect(code_lines[18 - 1].to_s).to eq(<<-EOL)
       @io.puts <<~EOM
 
         SyntaxSuggest: A syntax error was detected
@@ -54,7 +54,7 @@ module SyntaxSuggest
         DisplayCodeWithLineNumbers.new(
           lines: lines
         ).call
-      ).to eq(<<~'EOM'.indent(2))
+      ).to eq(<<~EOM.indent(2))
         1  User
         2    .where(name: 'schneems')
         3    .first
@@ -65,7 +65,7 @@ module SyntaxSuggest
           lines: lines,
           highlight_lines: lines[0]
         ).call
-      ).to eq(<<~'EOM')
+      ).to eq(<<~EOM)
         > 1  User
         > 2    .where(name: 'schneems')
         > 3    .first

--- a/spec/unit/clean_document_spec.rb
+++ b/spec/unit/clean_document_spec.rb
@@ -85,7 +85,7 @@ module SyntaxSuggest
       code_lines = doc.lines
 
       expect(code_lines[0].to_s.count($/)).to eq(5)
-      code_lines[1..-1].each do |line|
+      code_lines[1..].each do |line|
         expect(line.to_s.strip.length).to eq(0)
       end
     end

--- a/spec/unit/code_line_spec.rb
+++ b/spec/unit/code_line_spec.rb
@@ -5,7 +5,7 @@ require_relative "../spec_helper"
 module SyntaxSuggest
   RSpec.describe CodeLine do
     it "bug in keyword detection" do
-      lines = CodeLine.from_source(<<~'EOM')
+      lines = CodeLine.from_source(<<~EOM)
         def to_json(*opts)
           {
             type: :module,
@@ -19,7 +19,7 @@ module SyntaxSuggest
     it "supports endless method definitions" do
       skip("Unsupported ruby version") unless Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3")
 
-      line = CodeLine.from_source(<<~'EOM').first
+      line = CodeLine.from_source(<<~EOM).first
         def square(x) = x * x
       EOM
 
@@ -28,7 +28,7 @@ module SyntaxSuggest
     end
 
     it "retains original line value, after being marked invisible" do
-      line = CodeLine.from_source(<<~'EOM').first
+      line = CodeLine.from_source(<<~EOM).first
         puts "lol"
       EOM
       expect(line.line).to match('puts "lol"')
@@ -38,7 +38,7 @@ module SyntaxSuggest
     end
 
     it "knows which lines can be joined" do
-      code_lines = CodeLine.from_source(<<~'EOM')
+      code_lines = CodeLine.from_source(<<~EOM)
         user = User.
           where(name: 'schneems').
           first
@@ -50,7 +50,7 @@ module SyntaxSuggest
     end
 
     it "trailing if" do
-      code_lines = CodeLine.from_source(<<~'EOM')
+      code_lines = CodeLine.from_source(<<~EOM)
         puts "lol" if foo
         if foo
         end
@@ -60,7 +60,7 @@ module SyntaxSuggest
     end
 
     it "trailing unless" do
-      code_lines = CodeLine.from_source(<<~'EOM')
+      code_lines = CodeLine.from_source(<<~EOM)
         puts "lol" unless foo
         unless foo
         end

--- a/spec/unit/code_search_spec.rb
+++ b/spec/unit/code_search_spec.rb
@@ -12,13 +12,13 @@ module SyntaxSuggest
       search = CodeSearch.new(source)
       search.call
 
-      expect(search.invalid_blocks.join.strip).to eq(<<~'EOM'.strip)
+      expect(search.invalid_blocks.join.strip).to eq(<<~EOM.strip)
         class Lookups
       EOM
     end
 
     it "squished do regression" do
-      source = <<~'EOM'
+      source = <<~EOM
         def call
           trydo
 
@@ -47,14 +47,14 @@ module SyntaxSuggest
       search = CodeSearch.new(source)
       search.call
 
-      expect(search.invalid_blocks.join).to eq(<<~'EOM'.indent(2))
+      expect(search.invalid_blocks.join).to eq(<<~EOM.indent(2))
         trydo
         end # one
       EOM
     end
 
     it "regression test ambiguous end" do
-      source = <<~'EOM'
+      source = <<~EOM
         def call          # 0
             print "lol"   # 1
           end # one       # 2
@@ -64,13 +64,13 @@ module SyntaxSuggest
       search = CodeSearch.new(source)
       search.call
 
-      expect(search.invalid_blocks.join).to eq(<<~'EOM')
+      expect(search.invalid_blocks.join).to eq(<<~EOM)
         end # two         # 3
       EOM
     end
 
     it "regression dog test" do
-      source = <<~'EOM'
+      source = <<~EOM
         class Dog
           def bark
             puts "woof"
@@ -79,7 +79,7 @@ module SyntaxSuggest
       search = CodeSearch.new(source)
       search.call
 
-      expect(search.invalid_blocks.join).to eq(<<~'EOM')
+      expect(search.invalid_blocks.join).to eq(<<~EOM)
         class Dog
       EOM
       expect(search.invalid_blocks.first.lines.length).to eq(4)
@@ -99,7 +99,7 @@ module SyntaxSuggest
       search = CodeSearch.new(source)
       search.call
 
-      expect(search.invalid_blocks.join).to eq(<<~'EOM'.indent(2))
+      expect(search.invalid_blocks.join).to eq(<<~EOM.indent(2))
         Foo.call do |a
         end # one
       EOM
@@ -118,7 +118,7 @@ module SyntaxSuggest
       search = CodeSearch.new(source)
       search.call
 
-      expect(search.invalid_blocks.join).to eq(<<~'EOM'.indent(2))
+      expect(search.invalid_blocks.join).to eq(<<~EOM.indent(2))
         Foo.call do {
       EOM
     end
@@ -152,7 +152,7 @@ module SyntaxSuggest
     end
 
     it "handles no spaces between blocks" do
-      source = <<~'EOM'
+      source = <<~EOM
         context "foo bar" do
           it "bars the foo" do
             travel_to DateTime.new(2020, 10, 1, 10, 0, 0) do
@@ -172,7 +172,7 @@ module SyntaxSuggest
     it "records debugging steps to a directory" do
       Dir.mktmpdir do |dir|
         dir = Pathname(dir)
-        search = CodeSearch.new(<<~'EOM', record_dir: dir)
+        search = CodeSearch.new(<<~EOM, record_dir: dir)
           class OH
             def hello
             def hai
@@ -193,7 +193,7 @@ module SyntaxSuggest
     end
 
     it "def with missing end" do
-      search = CodeSearch.new(<<~'EOM')
+      search = CodeSearch.new(<<~EOM)
         class OH
           def hello
 
@@ -206,7 +206,7 @@ module SyntaxSuggest
 
       expect(search.invalid_blocks.join.strip).to eq("def hello")
 
-      search = CodeSearch.new(<<~'EOM')
+      search = CodeSearch.new(<<~EOM)
         class OH
           def hello
 
@@ -218,7 +218,7 @@ module SyntaxSuggest
 
       expect(search.invalid_blocks.join.strip).to eq("def hello")
 
-      search = CodeSearch.new(<<~'EOM')
+      search = CodeSearch.new(<<~EOM)
         class OH
           def hello
           def hai
@@ -227,7 +227,7 @@ module SyntaxSuggest
       EOM
       search.call
 
-      expect(search.invalid_blocks.join).to eq(<<~'EOM'.indent(2))
+      expect(search.invalid_blocks.join).to eq(<<~EOM.indent(2))
         def hello
       EOM
     end
@@ -244,13 +244,13 @@ module SyntaxSuggest
           highlight_lines: search.invalid_blocks.flat_map(&:lines)
         ).call
 
-        expect(document).to include(<<~'EOM')
+        expect(document).to include(<<~EOM)
           > 36      def filename
         EOM
       end
 
       it "Format Code blocks real world example" do
-        search = CodeSearch.new(<<~'EOM')
+        search = CodeSearch.new(<<~EOM)
           require 'rails_helper'
 
           RSpec.describe AclassNameHere, type: :worker do
@@ -291,7 +291,7 @@ module SyntaxSuggest
           highlight_lines: search.invalid_blocks.flat_map(&:lines)
         ).call
 
-        expect(document).to include(<<~'EOM')
+        expect(document).to include(<<~EOM)
              1  require 'rails_helper'
              2
              3  RSpec.describe AclassNameHere, type: :worker do
@@ -308,7 +308,7 @@ module SyntaxSuggest
     describe "needs improvement" do
       describe "mis-matched-indentation" do
         it "extra space before end" do
-          search = CodeSearch.new(<<~'EOM')
+          search = CodeSearch.new(<<~EOM)
             Foo.call
               def foo
                 puts "lol"
@@ -318,14 +318,14 @@ module SyntaxSuggest
           EOM
           search.call
 
-          expect(search.invalid_blocks.join).to eq(<<~'EOM')
+          expect(search.invalid_blocks.join).to eq(<<~EOM)
             Foo.call
             end # two
           EOM
         end
 
         it "stacked ends 2" do
-          search = CodeSearch.new(<<~'EOM')
+          search = CodeSearch.new(<<~EOM)
             def cat
               blerg
             end
@@ -339,7 +339,7 @@ module SyntaxSuggest
           EOM
           search.call
 
-          expect(search.invalid_blocks.join).to eq(<<~'EOM')
+          expect(search.invalid_blocks.join).to eq(<<~EOM)
             Foo.call do
             end # one
             end # two
@@ -348,7 +348,7 @@ module SyntaxSuggest
         end
 
         it "stacked ends " do
-          search = CodeSearch.new(<<~'EOM')
+          search = CodeSearch.new(<<~EOM)
             Foo.call
               def foo
                 puts "lol"
@@ -358,14 +358,14 @@ module SyntaxSuggest
           EOM
           search.call
 
-          expect(search.invalid_blocks.join).to eq(<<~'EOM')
+          expect(search.invalid_blocks.join).to eq(<<~EOM)
             Foo.call
             end
           EOM
         end
 
         it "missing space before end" do
-          search = CodeSearch.new(<<~'EOM')
+          search = CodeSearch.new(<<~EOM)
             Foo.call
 
               def foo
@@ -377,7 +377,7 @@ module SyntaxSuggest
           search.call
 
           # expand-1 and expand-2 seem to be broken?
-          expect(search.invalid_blocks.join).to eq(<<~'EOM')
+          expect(search.invalid_blocks.join).to eq(<<~EOM)
             Foo.call
             end
           EOM
@@ -386,7 +386,7 @@ module SyntaxSuggest
     end
 
     it "returns syntax error in outer block without inner block" do
-      search = CodeSearch.new(<<~'EOM')
+      search = CodeSearch.new(<<~EOM)
         Foo.call
           def foo
             puts "lol"
@@ -396,27 +396,27 @@ module SyntaxSuggest
       EOM
       search.call
 
-      expect(search.invalid_blocks.join).to eq(<<~'EOM')
+      expect(search.invalid_blocks.join).to eq(<<~EOM)
         Foo.call
         end # two
       EOM
     end
 
     it "doesn't just return an empty `end`" do
-      search = CodeSearch.new(<<~'EOM')
+      search = CodeSearch.new(<<~EOM)
         Foo.call
         end
       EOM
       search.call
 
-      expect(search.invalid_blocks.join).to eq(<<~'EOM')
+      expect(search.invalid_blocks.join).to eq(<<~EOM)
         Foo.call
         end
       EOM
     end
 
     it "finds multiple syntax errors" do
-      search = CodeSearch.new(<<~'EOM')
+      search = CodeSearch.new(<<~EOM)
         describe "hi" do
           Foo.call
           end
@@ -429,7 +429,7 @@ module SyntaxSuggest
       EOM
       search.call
 
-      expect(search.invalid_blocks.join).to eq(<<~'EOM'.indent(2))
+      expect(search.invalid_blocks.join).to eq(<<~EOM.indent(2))
         Foo.call
         end
         Bar.call
@@ -438,47 +438,47 @@ module SyntaxSuggest
     end
 
     it "finds a typo def" do
-      search = CodeSearch.new(<<~'EOM')
+      search = CodeSearch.new(<<~EOM)
         defzfoo
           puts "lol"
         end
       EOM
       search.call
 
-      expect(search.invalid_blocks.join).to eq(<<~'EOM')
+      expect(search.invalid_blocks.join).to eq(<<~EOM)
         defzfoo
         end
       EOM
     end
 
     it "finds a mis-matched def" do
-      search = CodeSearch.new(<<~'EOM')
+      search = CodeSearch.new(<<~EOM)
         def foo
           def blerg
         end
       EOM
       search.call
 
-      expect(search.invalid_blocks.join).to eq(<<~'EOM'.indent(2))
+      expect(search.invalid_blocks.join).to eq(<<~EOM.indent(2))
         def blerg
       EOM
     end
 
     it "finds a naked end" do
-      search = CodeSearch.new(<<~'EOM')
+      search = CodeSearch.new(<<~EOM)
         def foo
           end # one
         end # two
       EOM
       search.call
 
-      expect(search.invalid_blocks.join).to eq(<<~'EOM'.indent(2))
+      expect(search.invalid_blocks.join).to eq(<<~EOM.indent(2))
         end # one
       EOM
     end
 
     it "returns when no invalid blocks are found" do
-      search = CodeSearch.new(<<~'EOM')
+      search = CodeSearch.new(<<~EOM)
         def foo
           puts 'lol'
         end
@@ -489,14 +489,14 @@ module SyntaxSuggest
     end
 
     it "expands frontier by eliminating valid lines" do
-      search = CodeSearch.new(<<~'EOM')
+      search = CodeSearch.new(<<~EOM)
         def foo
           puts 'lol'
         end
       EOM
       search.create_blocks_from_untracked_lines
 
-      expect(search.code_lines.join).to eq(<<~'EOM')
+      expect(search.code_lines.join).to eq(<<~EOM)
         def foo
         end
       EOM

--- a/spec/unit/core_ext_spec.rb
+++ b/spec/unit/core_ext_spec.rb
@@ -8,7 +8,7 @@ module SyntaxSuggest
       Dir.mktmpdir do |dir|
         tmpdir = Pathname(dir)
         file = tmpdir.join("file.rb")
-        file.write(<<~'EOM'.strip)
+        file.write(<<~EOM.strip)
           print 'no newline
         EOM
 

--- a/spec/unit/explain_syntax_spec.rb
+++ b/spec/unit/explain_syntax_spec.rb
@@ -19,7 +19,6 @@ module SyntaxSuggest
       else
         expect(explain.errors.join).to include("unterminated string")
       end
-
     end
 
     it "handles %w[]" do

--- a/spec/unit/explain_syntax_spec.rb
+++ b/spec/unit/explain_syntax_spec.rb
@@ -14,7 +14,12 @@ module SyntaxSuggest
       ).call
 
       expect(explain.missing).to eq([])
-      expect(explain.errors.join).to include("unterminated string")
+      if SyntaxSuggest.use_prism_parser?
+        expect(explain.errors.join).to include("Expected a closing delimiter for the interpolated string")
+      else
+        expect(explain.errors.join).to include("unterminated string")
+      end
+
     end
 
     it "handles %w[]" do
@@ -191,7 +196,7 @@ module SyntaxSuggest
       ).call
 
       expect(explain.missing).to eq([])
-      expect(explain.errors).to eq(RipperErrors.new(source).call.errors)
+      expect(explain.errors).to eq(GetParseErrors.errors(source))
     end
 
     it "handles an unexpected rescue" do

--- a/spec/unit/scan_history_spec.rb
+++ b/spec/unit/scan_history_spec.rb
@@ -5,7 +5,7 @@ require_relative "../spec_helper"
 module SyntaxSuggest
   RSpec.describe ScanHistory do
     it "retains commits" do
-      source = <<~'EOM'
+      source = <<~EOM
         class OH         #  0
           def lol        #  1
             print 'lol   #  2
@@ -42,7 +42,7 @@ module SyntaxSuggest
     end
 
     it "is stashable" do
-      source = <<~'EOM'
+      source = <<~EOM
         class OH         #  0
           def lol        #  1
             print 'lol   #  2
@@ -79,7 +79,7 @@ module SyntaxSuggest
     end
 
     it "doesnt change if you dont't change it" do
-      source = <<~'EOM'
+      source = <<~EOM
         class OH         #  0
           def lol        #  1
             print 'lol   #  2

--- a/syntax_suggest.gemspec
+++ b/syntax_suggest.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.description = 'When you get an "unexpected end" in your syntax this gem helps you find it'
   spec.homepage = "https://github.com/ruby/syntax_suggest.git"
   spec.license = "MIT"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.5.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 3.0.0")
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/ruby/syntax_suggest.git"


### PR DESCRIPTION
Prism will be the parser in Ruby 3.3. We need to support 3.0+ so we will have to "dual boot" both parsers.

Todo: 

- [x] Add tests that exercise both Ripper and prism codepaths on CI
- [x] Handle https://github.com/ruby/prism/issues/1972 in `ripper_errors.rb`
- [ ] Update docs to not mention Ripper explicitly
- [ ] Consider different/cleaner APIs for separating out Ripper and Prism