### PR TITLE
Add support for the Prism parser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,22 @@ jobs:
       - name: test
         run: bin/rake test
         continue-on-error: ${{ matrix.ruby == 'head' }}
+
+  test-disable-prism:
+    needs: ruby-versions
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4.1.1
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - name: test
+        run: SYNTAX_SUGGEST_DISABLE_PRISM=1 bin/rake test
+        continue-on-error: ${{ matrix.ruby == 'head' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## HEAD (unreleased)
 
+- Support prism parser (https://github.com/ruby/syntax_suggest/pull/208).
 - No longer supports EOL versions of Ruby. (https://github.com/ruby/syntax_suggest/pull/210)
 - Handle Ruby 3.3 new eval source location format (https://github.com/ruby/syntax_suggest/pull/200).
 

--- a/Gemfile
+++ b/Gemfile
@@ -12,3 +12,4 @@ gem "standard"
 gem "ruby-prof"
 
 gem "benchmark-ips"
+gem "prism"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,8 +7,8 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
-    benchmark-ips (2.9.2)
-    diff-lcs (1.4.4)
+    benchmark-ips (2.12.0)
+    diff-lcs (1.5.0)
     json (2.7.0)
     language_server-protocol (3.17.0.3)
     lint_roller (1.1.0)
@@ -16,24 +16,25 @@ GEM
     parser (3.2.2.4)
       ast (~> 2.4.1)
       racc
+    prism (0.18.0)
     racc (1.7.3)
     rainbow (3.1.1)
     rake (12.3.3)
     regexp_parser (2.8.3)
     rexml (3.2.6)
-    rspec (3.10.0)
-      rspec-core (~> 3.10.0)
-      rspec-expectations (~> 3.10.0)
-      rspec-mocks (~> 3.10.0)
-    rspec-core (3.10.0)
-      rspec-support (~> 3.10.0)
-    rspec-expectations (3.10.0)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
+    rspec-core (3.12.2)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.3)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.10.0)
-    rspec-mocks (3.10.0)
+      rspec-support (~> 3.12.0)
+    rspec-mocks (3.12.6)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.10.0)
-    rspec-support (3.10.0)
+      rspec-support (~> 3.12.0)
+    rspec-support (3.12.1)
     rubocop (1.57.2)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
@@ -50,9 +51,9 @@ GEM
     rubocop-performance (1.19.1)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
-    ruby-prof (1.4.3)
+    ruby-prof (1.6.3)
     ruby-progressbar (1.13.0)
-    stackprof (0.2.16)
+    stackprof (0.2.25)
     standard (1.32.1)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
@@ -72,6 +73,7 @@ PLATFORMS
 
 DEPENDENCIES
   benchmark-ips
+  prism
   rake (~> 12.0)
   rspec (~> 3.0)
   ruby-prof
@@ -80,4 +82,4 @@ DEPENDENCIES
   syntax_suggest!
 
 BUNDLED WITH
-   2.3.14
+   2.4.21

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Unmatched `(', missing `)' ?
   5  end
 ```
 
-- Any ambiguous or unknown errors will be annotated by the original ripper error output:
+- Any ambiguous or unknown errors will be annotated by the original parser error output:
 
 <!--
 class Dog
@@ -133,7 +133,7 @@ end
 -->
 
 ```
-syntax error, unexpected end-of-input
+Expected an expression after the operator
 
   1  class Dog
   2    def meals_last_month

--- a/lib/syntax_suggest/api.rb
+++ b/lib/syntax_suggest/api.rb
@@ -5,23 +5,27 @@ require_relative "version"
 require "tmpdir"
 require "stringio"
 require "pathname"
+require "timeout"
 
-# rubocop:disable Style/IdenticalConditionalBranches
-if ENV["SYNTAX_SUGGEST_DISABLE_PRISM"] # For testing dual ripper/prism support
-  require "ripper"
+# We need Ripper loaded for `Prism.lex_compat` even if we're using Prism
+# for lexing and parsing
+require "ripper"
+
+# Prism is the new parser, replacing Ripper
+#
+# We need to "dual boot" both for now because syntax_suggest
+# supports older rubies that do not ship with syntax suggest.
+#
+# We also need the ability to control loading of this library
+# so we can test that both modes work correctly in CI.
+if (value = ENV["SYNTAX_SUGGEST_DISABLE_PRISM"])
+  warn "Skipping loading prism due to SYNTAX_SUGGEST_DISABLE_PRISM=#{value}"
 else
-  # TODO remove require
-  # Allow both to be loaded to enable more atomic commits
-  require "ripper"
   begin
     require "prism"
   rescue LoadError
-    require "ripper"
   end
 end
-# rubocop:enable Style/IdenticalConditionalBranches
-
-require "timeout"
 
 module SyntaxSuggest
   # Used to indicate a default value that cannot

--- a/lib/syntax_suggest/api.rb
+++ b/lib/syntax_suggest/api.rb
@@ -227,9 +227,6 @@ require_relative "lex_all"
 require_relative "code_line"
 require_relative "code_block"
 require_relative "block_expand"
-if !SyntaxSuggest.use_prism_parser?
-  require_relative "ripper_errors"
-end
 require_relative "priority_queue"
 require_relative "unvisited_lines"
 require_relative "around_block_scan"

--- a/lib/syntax_suggest/clean_document.rb
+++ b/lib/syntax_suggest/clean_document.rb
@@ -47,9 +47,9 @@ module SyntaxSuggest
   # ## Heredocs
   #
   # A heredoc is an way of defining a multi-line string. They can cause many
-  # problems. If left as a single line, Ripper would try to parse the contents
+  # problems. If left as a single line, the parser would try to parse the contents
   # as ruby code rather than as a string. Even without this problem, we still
-  # hit an issue with indentation
+  # hit an issue with indentation:
   #
   #    1 foo = <<~HEREDOC
   #    2  "Be yourself; everyone else is already taken.""

--- a/lib/syntax_suggest/code_block.rb
+++ b/lib/syntax_suggest/code_block.rb
@@ -81,7 +81,7 @@ module SyntaxSuggest
         # lines then the result cannot be invalid
         #
         # That means there's no reason to re-check all
-        # lines with ripper (which is expensive).
+        # lines with the parser (which is expensive).
         # Benchmark in commit message
         @valid = if lines.all? { |l| l.hidden? || l.empty? }
           true

--- a/lib/syntax_suggest/code_line.rb
+++ b/lib/syntax_suggest/code_line.rb
@@ -180,12 +180,19 @@ module SyntaxSuggest
     #     EOM
     #     expect(lines.first.trailing_slash?).to eq(true)
     #
-    def trailing_slash?
-      last = @lex.last
-      return false unless last
-      return false unless last.type == :on_sp
+    if SyntaxSuggest.use_prism_parser?
+      def trailing_slash?
+        last = @lex.last
+        last&.type == :on_tstring_end
+      end
+    else
+      def trailing_slash?
+        last = @lex.last
+        return false unless last
+        return false unless last.type == :on_sp
 
-      last.token == TRAILING_SLASH
+        last.token == TRAILING_SLASH
+      end
     end
 
     # Endless method detection

--- a/lib/syntax_suggest/explain_syntax.rb
+++ b/lib/syntax_suggest/explain_syntax.rb
@@ -3,6 +3,16 @@
 require_relative "left_right_lex_count"
 
 module SyntaxSuggest
+  class GetParseErrors
+    def self.errors(source)
+      if SyntaxSuggest.use_prism_parser?
+        Prism.parse(source).errors.map(&:message)
+      else
+        RipperErrors.new(source).call.errors
+      end
+    end
+  end
+
   # Explains syntax errors based on their source
   #
   # example:
@@ -94,7 +104,7 @@ module SyntaxSuggest
     # on the original ripper error messages
     def errors
       if missing.empty?
-        return RipperErrors.new(@code_lines.map(&:original).join).call.errors
+        return GetParseErrors.errors(@code_lines.map(&:original).join)
       end
 
       missing.map { |miss| why(miss) }

--- a/lib/syntax_suggest/explain_syntax.rb
+++ b/lib/syntax_suggest/explain_syntax.rb
@@ -2,6 +2,10 @@
 
 require_relative "left_right_lex_count"
 
+if !SyntaxSuggest.use_prism_parser?
+  require_relative "ripper_errors"
+end
+
 module SyntaxSuggest
   class GetParseErrors
     def self.errors(source)
@@ -25,8 +29,8 @@ module SyntaxSuggest
   #   # => "Unmatched keyword, missing `end' ?"
   #
   # When the error cannot be determined by lexical counting
-  # then ripper is run against the input and the raw ripper
-  # errors returned.
+  # then the parser is run against the input and the raw
+  # errors are returned.
   #
   # Example:
   #
@@ -101,7 +105,7 @@ module SyntaxSuggest
     # Returns an array of syntax error messages
     #
     # If no missing pairs are found it falls back
-    # on the original ripper error messages
+    # on the original error messages
     def errors
       if missing.empty?
         return GetParseErrors.errors(@code_lines.map(&:original).join)

--- a/lib/syntax_suggest/explain_syntax.rb
+++ b/lib/syntax_suggest/explain_syntax.rb
@@ -108,7 +108,7 @@ module SyntaxSuggest
     # on the original error messages
     def errors
       if missing.empty?
-        return GetParseErrors.errors(@code_lines.map(&:original).join)
+        return GetParseErrors.errors(@code_lines.map(&:original).join).uniq
       end
 
       missing.map { |miss| why(miss) }

--- a/lib/syntax_suggest/lex_all.rb
+++ b/lib/syntax_suggest/lex_all.rb
@@ -32,18 +32,15 @@ module SyntaxSuggest
       }
     end
 
-    # rubocop:disable Style/IdenticalConditionalBranches
     if SyntaxSuggest.use_prism_parser?
       def self.lex(source, line_number)
-        # Prism.lex_compat(source, line: line_number).value.sort_by {|values| values[0] }
-        Ripper::Lexer.new(source, "-", line_number).parse.sort_by(&:pos)
+        Prism.lex_compat(source, line: line_number).value.sort_by { |values| values[0] }
       end
     else
       def self.lex(source, line_number)
         Ripper::Lexer.new(source, "-", line_number).parse.sort_by(&:pos)
       end
     end
-    # rubocop:enable Style/IdenticalConditionalBranches
 
     def to_a
       @lex

--- a/lib/syntax_suggest/lex_all.rb
+++ b/lib/syntax_suggest/lex_all.rb
@@ -3,10 +3,18 @@
 module SyntaxSuggest
   # Ripper.lex is not guaranteed to lex the entire source document
   #
-  # lex = LexAll.new(source: source)
-  # lex.each do |value|
-  #   puts value.line
-  # end
+  # This class guarantees the whole document is lex-ed by iteratively
+  # lexing the document where ripper stopped.
+  #
+  # Prism likely doesn't have the same problem. Once ripper support is removed
+  # we can likely reduce the complexity here if not remove the whole concept.
+  #
+  # Example usage:
+  #
+  #   lex = LexAll.new(source: source)
+  #   lex.each do |value|
+  #     puts value.line
+  #   end
   class LexAll
     include Enumerable
 

--- a/lib/syntax_suggest/ripper_errors.rb
+++ b/lib/syntax_suggest/ripper_errors.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 module SyntaxSuggest
-  # Capture parse errors from ripper
+  # Capture parse errors from Ripper
+  #
+  # Prism returns the errors with their messages, but Ripper
+  # does not. To get them we must make a custom subclass.
   #
   # Example:
   #

--- a/spec/unit/api_spec.rb
+++ b/spec/unit/api_spec.rb
@@ -8,6 +8,12 @@ end
 
 module SyntaxSuggest
   RSpec.describe "Top level SyntaxSuggest api" do
+    it "doesn't load prism if env var is set" do
+      skip("SYNTAX_SUGGEST_DISABLE_PRISM not set") unless ENV["SYNTAX_SUGGEST_DISABLE_PRISM"]
+
+      expect(SyntaxSuggest.use_prism_parser?).to be_falsey
+    end
+
     it "has a `handle_error` interface" do
       fake_error = Object.new
       def fake_error.message

--- a/spec/unit/explain_syntax_spec.rb
+++ b/spec/unit/explain_syntax_spec.rb
@@ -14,7 +14,11 @@ module SyntaxSuggest
       ).call
 
       expect(explain.missing).to eq([])
-      expect(explain.errors.join).to include("unterminated string")
+      if SyntaxSuggest.use_prism_parser?
+        expect(explain.errors.join).to include("Expected a closing delimiter for the interpolated string")
+      else
+        expect(explain.errors.join).to include("unterminated string")
+      end
     end
 
     it "handles %w[]" do
@@ -191,7 +195,7 @@ module SyntaxSuggest
       ).call
 
       expect(explain.missing).to eq([])
-      expect(explain.errors).to eq(RipperErrors.new(source).call.errors)
+      expect(explain.errors).to eq(GetParseErrors.errors(source))
     end
 
     it "handles an unexpected rescue" do

--- a/spec/unit/lex_all_spec.rb
+++ b/spec/unit/lex_all_spec.rb
@@ -17,9 +17,6 @@ module SyntaxSuggest
         end            # 9
       EOM
 
-      # raw_lex = Ripper.lex(source)
-      # expect(raw_lex.to_s).to_not include("dog")
-
       lex = LexAll.new(source: source)
       expect(lex.map(&:token).to_s).to include("dog")
       expect(lex.first.line).to eq(1)


### PR DESCRIPTION
Prism will be the parser in Ruby 3.3. We need to support Ruby 3.0+, so we must "dual boot" both prism and Ripper.

Todo: 

- [x] Add tests that exercise both Ripper and prism codepaths on CI
- [x] Handle https://github.com/ruby/prism/issues/1972 in `ripper_errors.rb`
- [x] Update docs to not mention Ripper explicitly
- [x] Consider different/cleaner APIs for separating out Ripper and Prism