### PR TITLE
Change assertion to not rely on exact text from prism

### DIFF
--- a/spec/unit/explain_syntax_spec.rb
+++ b/spec/unit/explain_syntax_spec.rb
@@ -14,11 +14,7 @@ module SyntaxSuggest
       ).call
 
       expect(explain.missing).to eq([])
-      if SyntaxSuggest.use_prism_parser?
-        expect(explain.errors.join).to include("Expected a closing delimiter for the interpolated string")
-      else
-        expect(explain.errors.join).to include("unterminated string")
-      end
+      expect(explain.errors.join.strip).to_not be_empty
     end
 
     it "handles %w[]" do


### PR DESCRIPTION
The original ripper test was very stable as the output didn't change. Prism is under active development and changing their output shouldn't cause a failure to the ruby/ruby test suite like https://github.com/ruby/ruby/actions/runs/7104601478/job/19339940315.

This commit moves from checking exact output to asserting that the string we get back is not empty. This should give the same level of confidence that some error message was caught, and is less brittle.