### PR TITLE
A gem executable should not use require_relative

### DIFF
--- a/exe/syntax_suggest
+++ b/exe/syntax_suggest
@@ -1,11 +1,6 @@
 #!/usr/bin/env ruby
 
-begin
-  require_relative "../lib/syntax_suggest/api"
-rescue LoadError
-  # for default gems
-  require "syntax_suggest/api"
-end
+require "syntax_suggest/api"
 
 SyntaxSuggest::Cli.new(
   argv: ARGV


### PR DESCRIPTION
Otherwise it makes incorrect assumption about RubyGems layout.
RubyGems always guarantees the gem's `lib` is in $LOAD_PATH.

Follow up of https://github.com/ruby/syntax_suggest/pull/226