### PR TITLE
Added 'skip changelog' label for dependabot update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+    labels:
+      - 'skip changelog'


### PR DESCRIPTION
We should ignore to check changelog for dependabot update.

ref. https://github.com/ruby/syntax_suggest/actions/runs/11554424291/job/32157600639