### PR TITLE
Make benchmark examples as optional

### DIFF
--- a/spec/integration/syntax_suggest_spec.rb
+++ b/spec/integration/syntax_suggest_spec.rb
@@ -4,6 +4,10 @@ require_relative "../spec_helper"
 
 module SyntaxSuggest
   RSpec.describe "Integration tests that don't spawn a process (like using the cli)" do
+    before(:each) do
+      skip "Benchmark is not available" unless defined?(::Benchmark)
+    end
+
     it "does not timeout on massive files" do
       next unless ENV["SYNTAX_SUGGEST_TIMEOUT"]
 
@@ -235,5 +239,5 @@ module SyntaxSuggest
         end_is_missing_here
       EOM
     end
-  end if defined?(::Benchmark)
+  end
 end

--- a/spec/integration/syntax_suggest_spec.rb
+++ b/spec/integration/syntax_suggest_spec.rb
@@ -235,5 +235,5 @@ module SyntaxSuggest
         end_is_missing_here
       EOM
     end
-  end
+  end if defined?(::Benchmark)
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,10 @@
 require "bundler/setup"
 require "syntax_suggest/api"
 
-require "benchmark"
+begin
+  require "benchmark"
+rescue LoadError
+end
 require "tempfile"
 
 RSpec.configure do |config|


### PR DESCRIPTION
from https://bugs.ruby-lang.org/issues/20309

`benchmark` library will be changed bundled gems at Ruby 3.5. We should mark related examples as optional.