### PR TITLE
Test multiple prism versions in CI + Fix Prism head

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,12 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
+        prism_version:
+          - 1.2.0 # Shipped with Ruby 3.4 as default parser https://www.ruby-lang.org/en/news/2024/12/25/ruby-3-4-0-released/
+          - 1.8.0
+          - head
+    env:
+      PRISM_VERSION: ${{ matrix.prism_version }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -40,6 +46,9 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
+      - name: Use latest prism version (head only)
+        if: matrix.prism_version == 'head'
+        run: bundle update prism
       - name: test
         run: bin/rake test
         continue-on-error: ${{ matrix.ruby == 'head' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## HEAD (unreleased)
 
+- Fix: Correctly identify trailing slashes when using Prism > 1.8.0. (https://github.com/ruby/syntax_suggest/pull/241)
 - Internal: Add tests to multiple versions of prism
 
 ## 2.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD (unreleased)
 
+- Internal: Add tests to multiple versions of prism
+
 ## 2.0.2
 
 - Fix: Separate multiple parser errors by newline. (https://github.com/ruby/syntax_suggest/pull/232)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## HEAD (unreleased)
 
-- Fix: Correctly identify trailing slashes when using Prism > 1.8.0. (https://github.com/ruby/syntax_suggest/pull/241)
+- Fix: Correctly identify trailing slashes when using Prism > 1.8.0. (https://github.com/ruby/syntax_suggest/pull/243)
 - Internal: Add tests to multiple versions of prism
 
 ## 2.0.2

--- a/Gemfile
+++ b/Gemfile
@@ -12,4 +12,12 @@ gem "standard"
 gem "ruby-prof"
 
 gem "benchmark-ips"
-gem "prism"
+
+case ENV["PRISM_VERSION"]&.strip&.downcase
+when "head"
+  gem "prism", github: "ruby/prism"
+when nil, ""
+  gem "prism"
+else
+  gem "prism", ENV["PRISM_VERSION"]
+end

--- a/lib/syntax_suggest/code_line.rb
+++ b/lib/syntax_suggest/code_line.rb
@@ -180,21 +180,17 @@ module SyntaxSuggest
     #     EOM
     #     expect(lines.first.trailing_slash?).to eq(true)
     #
-    if SyntaxSuggest.use_prism_parser? && Prism::VERSION <= "1.8.0"
-      # Older versions of prism didn't correctly emit on_sp
-      def trailing_slash?
-        last = @lex.last
-        return false unless last
+    def trailing_slash?
+      last = @lex.last
 
-        last.type == :on_tstring_end || (last.type == :on_sp && last.token == TRAILING_SLASH)
-      end
-    else
-      def trailing_slash?
-        last = @lex.last
-        return false unless last
-        return false unless last.type == :on_sp
-
+      # Older versions of prism diverged slightly from Ripper in compatibility mode
+      case last&.type
+      when :on_sp
         last.token == TRAILING_SLASH
+      when :on_tstring_end
+        true
+      else
+        false
       end
     end
 

--- a/lib/syntax_suggest/code_line.rb
+++ b/lib/syntax_suggest/code_line.rb
@@ -180,10 +180,13 @@ module SyntaxSuggest
     #     EOM
     #     expect(lines.first.trailing_slash?).to eq(true)
     #
-    if SyntaxSuggest.use_prism_parser?
+    if SyntaxSuggest.use_prism_parser? && Prism::VERSION <= "1.8.0"
+      # Older versions of prism didn't correctly emit on_sp
       def trailing_slash?
         last = @lex.last
-        last&.type == :on_tstring_end
+        return false unless last
+
+        last.type == :on_tstring_end || (last.type == :on_sp && last.token == TRAILING_SLASH)
       end
     else
       def trailing_slash?


### PR DESCRIPTION
- Add prism versions to ci: PR https://github.com/ruby/syntax_suggest/pull/241 is adding branching logic for different prism versions based on changes to HEAD. I want to guard against regressions. This change adds the ability to test against multiple versions, including HEAD (which is currently failing on main, but passing on their branch).
  - https://github.com/ruby/ruby/pull/15914
  - https://github.com/ruby/prism/pull/3859
- Cherry-picked PR https://github.com/ruby/syntax_suggest/pull/241 to get tests to pass on head.
- Re-worked the logic, details in the commit message