### PR TITLE
Add hint when `if` or `unless` is followed by `do`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD (unreleased)
 
+- Added: Support for detecting `if ... do` (accidental `do` after an `if` or `unless`)  (https://github.com/ruby/syntax_suggest/pull/244)
+
 ## 2.0.3
 
 - Fix: Correctly identify trailing slashes when using Prism > 1.8.0. (https://github.com/ruby/syntax_suggest/pull/243)

--- a/spec/integration/syntax_suggest_spec.rb
+++ b/spec/integration/syntax_suggest_spec.rb
@@ -209,6 +209,32 @@ module SyntaxSuggest
       EOM
     end
 
+    it "if .. do" do
+      source = <<~EOM
+        describe "something" do
+          if "does something" do
+            print "foo"
+          end
+        end
+      EOM
+
+      io = StringIO.new
+      SyntaxSuggest.call(
+        io: io,
+        source: source
+      )
+      out = io.string
+      expect(out).to include(<<~EOM)
+        Unmatched keyword, missing `end' ?
+        Both `if` and `do` require an `end`.
+
+          1  describe "something" do
+        > 2    if "does something" do
+        > 4    end
+          5  end
+      EOM
+    end
+
     it "empty else" do
       source = <<~EOM
         class Foo


### PR DESCRIPTION
A typo in RSpec is typing `if` instead of `it`. Depending on the font, they can be hard to distinguish at a glance:

```ruby
if "does something" do  # Should be `it "does something" do`
  # ...
end
```

This results in a confusing "Unmatched keyword, missing 'end'?" error because both `if` and `do` require their own `end`. And some keywords like `while` and `loop` take `do`, so it's not always obvious that `if` or `unless` don't.

The message needs to accommodate a scenario where it's unknown if the value inside accepts a block like:

```ruby
if method_call do
end
```

This might be perfectly valid ruby code, so you wouldn't want to assert "if does not take a do" (since that's not the problem...the problem is that both if and do require an `end` to close, but the code doesn't provide that.


Before:

```
Unmatched keyword, missing `end' ?

  2  describe "something" do
> 3    if "does something" do
> 5    end
  6  end
```

After:

```
Unmatched keyword, missing `end' ?
Both `if` and `do` require an `end`.

  2  describe "something" do
> 3    if "does something" do
> 5    end
  6  end
```

Close #206