### PR TITLE
Fix typo for `%I` delimiter check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.0.3
 
 - Fix: Correctly identify trailing slashes when using Prism > 1.8.0. (https://github.com/ruby/syntax_suggest/pull/243)
+- Fix: Correctly handle `%I` delimiters. (https://github.com/ruby/syntax_suggest/pull/249)
 - Internal: Add tests to multiple versions of prism
 
 ## 2.0.2

--- a/lib/syntax_suggest/left_right_lex_count.rb
+++ b/lib/syntax_suggest/left_right_lex_count.rb
@@ -62,7 +62,7 @@ module SyntaxSuggest
         # Means it's a string or a symbol `"{"` rather than being
         # part of a data structure (like a hash) `{ a: b }`
         # ignore it.
-      when :on_words_beg, :on_symbos_beg, :on_qwords_beg,
+      when :on_words_beg, :on_symbols_beg, :on_qwords_beg,
            :on_qsymbols_beg, :on_regexp_beg, :on_tstring_beg
         # ^^^
         # Handle shorthand syntaxes like `%Q{ i am a string }`


### PR DESCRIPTION
Also add tests for the other types which currently don't have one