### PR TITLE
Remove now unneeded ripper workaround

### DIFF
--- a/lib/syntax_suggest/clean_document.rb
+++ b/lib/syntax_suggest/clean_document.rb
@@ -86,7 +86,7 @@ module SyntaxSuggest
   class CleanDocument
     def initialize(source:)
       lines = clean_sweep(source: source)
-      @document = CodeLine.from_source(lines.join, lines: lines)
+      @document = CodeLine.from_source(lines.join)
     end
 
     # Call all of the document "cleaners"

--- a/lib/syntax_suggest/code_line.rb
+++ b/lib/syntax_suggest/code_line.rb
@@ -26,10 +26,9 @@ module SyntaxSuggest
 
     # Returns an array of CodeLine objects
     # from the source string
-    def self.from_source(source, lines: nil)
-      lines ||= source.lines
-      lex_array_for_line = LexAll.new(source: source, source_lines: lines).each_with_object(Hash.new { |h, k| h[k] = [] }) { |lex, hash| hash[lex.line] << lex }
-      lines.map.with_index do |line, index|
+    def self.from_source(source)
+      lex_array_for_line = LexAll.new(source: source).each_with_object(Hash.new { |h, k| h[k] = [] }) { |lex, hash| hash[lex.line] << lex }
+      source.lines.map.with_index do |line, index|
         CodeLine.new(
           line: line,
           index: index,

--- a/lib/syntax_suggest/lex_all.rb
+++ b/lib/syntax_suggest/lex_all.rb
@@ -1,13 +1,7 @@
 # frozen_string_literal: true
 
 module SyntaxSuggest
-  # Ripper.lex is not guaranteed to lex the entire source document
-  #
-  # This class guarantees the whole document is lex-ed by iteratively
-  # lexing the document where ripper stopped.
-  #
-  # Prism likely doesn't have the same problem. Once ripper support is removed
-  # we can likely reduce the complexity here if not remove the whole concept.
+  # Lexes the whole source and wraps the tokens in `LexValue`
   #
   # Example usage:
   #
@@ -18,21 +12,8 @@ module SyntaxSuggest
   class LexAll
     include Enumerable
 
-    def initialize(source:, source_lines: nil)
+    def initialize(source:)
       @lex = self.class.lex(source, 1)
-      lineno = @lex.last[0][0] + 1
-      source_lines ||= source.lines
-      last_lineno = source_lines.length
-
-      until lineno >= last_lineno
-        lines = source_lines[lineno..]
-
-        @lex.concat(
-          self.class.lex(lines.join, lineno + 1)
-        )
-
-        lineno = @lex.last[0].first + 1
-      end
 
       last_lex = nil
       @lex.map! { |elem|


### PR DESCRIPTION
See for context https://github.com/ruby/syntax_suggest/pull/23/changes/293b673a3bd1fa0b35a7bc6d99285e806ebb90f0

I confirmed that the bug was present in 2.7.8 and got fixed in 3.0.0

[skip changelog]