### PR TITLE
Enforce frozen_string_literal comment and enable performance cops

### DIFF
--- a/.rubocop_extra.yml
+++ b/.rubocop_extra.yml
@@ -1,0 +1,9 @@
+require:
+  - rubocop-performance
+
+Style/FrozenStringLiteralComment:
+  Enabled: true
+  EnforcedStyle: always
+
+Performance:
+  Enabled: true

--- a/.standard.yml
+++ b/.standard.yml
@@ -1,1 +1,3 @@
 ruby_version: 3.3.0
+extend_config:
+  - .rubocop_extra.yml

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem "rake", "~> 13.0"
 gem "rspec", "~> 3.0"
 gem "stackprof"
 gem "standard"
+gem "rubocop-performance"
 gem "ruby-prof"
 
 gem "benchmark"


### PR DESCRIPTION
Every Ruby file in this project already includes `# frozen_string_literal: true`, but the linter never enforced that convention. This means new files could silently omit the comment without CI catching it.

This PR uses standardrb's `extend_config` to layer additional RuboCop rules on top of the existing Standard configuration:

- **Style/FrozenStringLiteralComment** — enforces the `# frozen_string_literal: true` comment on every file, codifying the existing project convention.
- **rubocop-performance** — enables the Performance cop department to catch common inefficiencies like unnecessary string allocations, redundant `flat_map`, and similar patterns.

No source files needed to change because the convention was already universally followed.