### PR TITLE
Fix SYNTAX_SUGGEST_DEBUG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD (unreleased)
 
+- Fix: `SYNTAX_SUGGEST_DEBUG` no longer raises `NoMethodError`. Previously this code path called `$stderr.warn` which is a private method. Now it uses `warn` instead.
+
 ## 3.0.0
 
 - Changed: Minimum supported Ruby version is now 3.3. (https://github.com/ruby/syntax_suggest/pull/246)

--- a/lib/syntax_suggest/core_ext.rb
+++ b/lib/syntax_suggest/core_ext.rb
@@ -33,8 +33,8 @@ module SyntaxSuggest
         end
       rescue => e
         if ENV["SYNTAX_SUGGEST_DEBUG"]
-          $stderr.warn(e.message)
-          $stderr.warn(e.backtrace)
+          warn(e.message)
+          warn(e.backtrace)
         end
 
         # Ignore internal errors

--- a/spec/integration/ruby_command_line_spec.rb
+++ b/spec/integration/ruby_command_line_spec.rb
@@ -185,5 +185,34 @@ module SyntaxSuggest
         expect(out).to include("Invalid break")
       end
     end
+
+    it "SYNTAX_SUGGEST_DEBUG reports a rescued internal error instead of masking it" do
+      Dir.mktmpdir do |dir|
+        tmpdir = Pathname(dir)
+
+        # Force `SyntaxSuggest.call` to raise so the rescue in `detailed_message` fires
+        monkeypatch = tmpdir.join("raise_monkeypatch.rb")
+        monkeypatch.write <<~EOM
+          require "syntax_suggest/api"
+
+          module SyntaxSuggest
+            def self.call(*args, **kwargs)
+              raise "boom from monkeypatch"
+            end
+          end
+        EOM
+
+        script = tmpdir.join("script.rb")
+        script.write <<~EOM
+          def lol
+            puts "haha"
+        EOM
+
+        out = `SYNTAX_SUGGEST_DEBUG=1 #{ruby} -I#{lib_dir} -rsyntax_suggest -r#{monkeypatch} #{script} 2>&1`
+
+        expect($?.success?).to be_falsey
+        expect(out).to include("boom from monkeypatch")
+      end
+    end
   end
 end


### PR DESCRIPTION
The code in the rescue block of the core extension wasn't exercised in test. It calls `$stderr.warn` which is a private method so it would error. This adds a test to exercise that code and fixes the no method error.