### PR TITLE
Fix the SYNTAX_SUGGEST_DEBUG spec on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## HEAD (unreleased)
 
 - Fix: `SYNTAX_SUGGEST_DEBUG` no longer raises `NoMethodError`. Previously this code path called `$stderr.warn` which is a private method. Now it uses `warn` instead.
+- Internal: Fix the `SYNTAX_SUGGEST_DEBUG` integration spec on Windows.
 
 ## 3.0.0
 

--- a/spec/integration/ruby_command_line_spec.rb
+++ b/spec/integration/ruby_command_line_spec.rb
@@ -208,7 +208,7 @@ module SyntaxSuggest
             puts "haha"
         EOM
 
-        out = `SYNTAX_SUGGEST_DEBUG=1 #{ruby} -I#{lib_dir} -rsyntax_suggest -r#{monkeypatch} #{script} 2>&1`
+        out = IO.popen({"SYNTAX_SUGGEST_DEBUG" => "1"}, "#{ruby} -I#{lib_dir} -rsyntax_suggest -r#{monkeypatch} #{script} 2>&1", &:read)
 
         expect($?.success?).to be_falsey
         expect(out).to include("boom from monkeypatch")


### PR DESCRIPTION
The `SYNTAX_SUGGEST_DEBUG` spec added in #261 fails on Windows. The backtick command runs through cmd.exe, which does not understand the POSIX `VAR=value command` form and tries to run `SYNTAX_SUGGEST_DEBUG` as a command. The spec then gets `'SYNTAX_SUGGEST_DEBUG' is not recognized as an internal or external command` instead of the expected error.

https://github.com/ruby/ruby/actions/runs/34515928495/job/103002536286

This passes the variable through the env hash of `IO.popen` instead. It is a forward-port of https://github.com/ruby/ruby/pull/18757, so the spec now matches ruby/ruby byte for byte. The CI here runs on Ubuntu only and cannot catch this.

Generated with [Claude Code](https://claude.com/claude-code)
